### PR TITLE
Add multithreaded search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,17 @@ jobs:
           make -C NeraChessTests config=debug -B -j"$jobs" CXXFLAGS="$sanitizer_flags" LDFLAGS='-fsanitize=address,undefined'
           ./bin/Debug/NeraChessTests/NeraChessTests
 
+      - name: Build and run thread-sanitized regressions
+        run: |
+          jobs="$(nproc)"
+          sanitizer_flags='-fsanitize=thread -fno-omit-frame-pointer -O1 -g'
+          make -C NeraChessEngine config=debug -B -j"$jobs" CXXFLAGS="$sanitizer_flags"
+          make -C NeraChessSearch config=debug -B -j"$jobs" CXXFLAGS="$sanitizer_flags"
+          make -C NeraChessUCI config=debug -B -j"$jobs" CXXFLAGS="$sanitizer_flags" LDFLAGS='-fsanitize=thread'
+          make -C NeraChessTests config=debug -B -j"$jobs" CXXFLAGS="$sanitizer_flags" LDFLAGS='-fsanitize=thread'
+          TSAN_OPTIONS='halt_on_error=1 second_deadlock_stack=1' ./bin/Debug/NeraChessTests/NeraChessTests
+          TSAN_OPTIONS='halt_on_error=1 second_deadlock_stack=1' python3 scripts/Test-UciPonder.py ./bin/Debug/NeraChessUCI/NeraChessUCI
+
   macos:
     name: macOS
     runs-on: macos-latest

--- a/NeraChessApp/src/ChessPlayers/Bot/NeraChessBot.cpp
+++ b/NeraChessApp/src/ChessPlayers/Bot/NeraChessBot.cpp
@@ -3,13 +3,17 @@
 #include "Resources.h"
 #include "TimeManagement.h"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
+#include <thread>
 
 NeraChessBot::NeraChessBot()
     : m_OpeningBookPath(NeraChessApp::GetResourcePath("OpeningBook/OpeningBook.txt")),
       m_OpeningBook(m_OpeningBookPath)
 {
+    const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
+    m_SearchEngine.SetThreadCount(std::min<size_t>(4, hardwareThreads));
     if (!m_OpeningBook.IsAvailable())
         std::cout << "Opening book missing (" << m_OpeningBookPath << ")\n";
 }

--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -7,6 +7,10 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <exception>
+#include <system_error>
+#include <thread>
+#include <utility>
 
 namespace NeraChessSearch
 {
@@ -18,47 +22,165 @@ namespace NeraChessSearch
     }
 
     SearchEngine::SearchEngine(size_t hashMegabytes)
-        : m_TranspositionTable(hashMegabytes)
+        : m_TranspositionTable(std::make_shared<TranspositionTable>(hashMegabytes)),
+          m_SharedState(std::make_shared<SharedSearchState>())
+    {
+    }
+
+    SearchEngine::SearchEngine(size_t workerIndex,
+        std::shared_ptr<TranspositionTable> transpositionTable,
+        std::shared_ptr<SharedSearchState> sharedState)
+        : m_TranspositionTable(std::move(transpositionTable)),
+          m_SharedState(std::move(sharedState)),
+          m_WorkerIndex(workerIndex)
     {
     }
 
     void SearchEngine::PrepareSearch(bool pondering)
     {
-        m_StopRequested = false;
-        m_TimeControlStartMilliseconds = pondering ? -1 : SteadyMilliseconds();
+        m_SharedState->stopRequested = false;
+        m_SharedState->searchStopped = false;
+        m_SharedState->timeControlStartMilliseconds = pondering ? -1 : SteadyMilliseconds();
         m_TimeControlPrepared = true;
     }
 
     void SearchEngine::PonderHit()
     {
         int64_t pondering = -1;
-        m_TimeControlStartMilliseconds.compare_exchange_strong(
+        m_SharedState->timeControlStartMilliseconds.compare_exchange_strong(
             pondering, SteadyMilliseconds());
     }
 
     void SearchEngine::NewGame()
     {
-        m_StopRequested = false;
+        m_SharedState->stopRequested = false;
+        m_SharedState->searchStopped = false;
+        m_SharedState->nodes = 0;
         m_TimeControlPrepared = false;
-        m_TimeControlStartMilliseconds = 0;
-        m_TranspositionTable.Clear();
+        m_SharedState->timeControlStartMilliseconds = 0;
+        m_TranspositionTable->Clear();
+        ResetHeuristics();
+        for (const std::unique_ptr<SearchEngine>& helper : m_HelperEngines)
+            helper->ResetHeuristics();
+    }
+
+    void SearchEngine::ResizeHash(size_t megabytes)
+    {
+        m_TranspositionTable->Resize(megabytes);
+    }
+
+    void SearchEngine::SetThreadCount(size_t threadCount)
+    {
+        const size_t requestedThreadCount = std::clamp<size_t>(threadCount, 1, 256);
+        std::vector<std::unique_ptr<SearchEngine>> helpers;
+        helpers.reserve(requestedThreadCount - 1);
+        for (size_t workerIndex = 1; workerIndex < requestedThreadCount; ++workerIndex)
+        {
+            helpers.push_back(std::unique_ptr<SearchEngine>(
+                new SearchEngine(workerIndex, m_TranspositionTable, m_SharedState)));
+        }
+        m_HelperEngines = std::move(helpers);
+        m_ThreadCount = requestedThreadCount;
+    }
+
+    void SearchEngine::ResetHeuristics()
+    {
         m_KillerMoves = {};
         m_History = {};
         m_CounterMoves = {};
+        m_PvTable = {};
+        m_PvLength = {};
     }
 
     SearchResult SearchEngine::Search(const ChessBoard& position, const SearchLimits& limits)
     {
+        m_StartTime = std::chrono::steady_clock::now();
         if (!m_TimeControlPrepared.exchange(false))
-            m_TimeControlStartMilliseconds = SteadyMilliseconds();
+            m_SharedState->timeControlStartMilliseconds = SteadyMilliseconds();
+        m_SharedState->searchStopped = false;
+        m_SharedState->nodes = 0;
+        m_TranspositionTable->NewSearch();
+
+        std::vector<std::jthread> helperThreads;
+        helperThreads.reserve(m_HelperEngines.size());
+        std::vector<std::exception_ptr> helperErrors(m_HelperEngines.size());
+        SearchResult result;
+        try
+        {
+            for (size_t helperIndex = 0; helperIndex < m_HelperEngines.size(); ++helperIndex)
+            {
+                const std::unique_ptr<SearchEngine>& helper = m_HelperEngines[helperIndex];
+                SearchLimits helperLimits = limits;
+                helperLimits.iterationCallback = {};
+                try
+                {
+                    helperThreads.emplace_back([worker = helper.get(), &position,
+                        helperLimits = std::move(helperLimits), &helperErrors, helperIndex]() mutable
+                    {
+                        try
+                        {
+                            worker->SearchWorker(position, helperLimits);
+                        }
+                        catch (...)
+                        {
+                            helperErrors[helperIndex] = std::current_exception();
+                            worker->m_SharedState->searchStopped = true;
+                        }
+                    });
+                }
+                catch (const std::system_error&)
+                {
+                    // Continue with the workers the operating system could create.
+                    break;
+                }
+            }
+            result = SearchWorker(position, limits);
+        }
+        catch (...)
+        {
+            m_SharedState->searchStopped = true;
+            for (std::jthread& helperThread : helperThreads)
+            {
+                if (helperThread.joinable())
+                    helperThread.join();
+            }
+            throw;
+        }
+
+        m_SharedState->searchStopped = true;
+        for (std::jthread& helperThread : helperThreads)
+            helperThread.join();
+        for (const std::exception_ptr& helperError : helperErrors)
+        {
+            if (helperError)
+                std::rethrow_exception(helperError);
+        }
+
+        result.nodes = m_SharedState->nodes.load(std::memory_order_relaxed);
+        result.selectiveDepth = m_SelectiveDepth;
+        for (size_t helperIndex = 0; helperIndex < helperThreads.size(); ++helperIndex)
+        {
+            result.selectiveDepth = std::max(result.selectiveDepth,
+                m_HelperEngines[helperIndex]->m_SelectiveDepth);
+        }
+        result.hashFullPermill = m_TranspositionTable->HashFullPermill();
+        result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - m_StartTime);
+        return result;
+    }
+
+    SearchResult SearchEngine::SearchWorker(const ChessBoard& position,
+        const SearchLimits& limits)
+    {
         m_Limits = limits;
         m_Limits.maxDepth = std::clamp(m_Limits.maxDepth, 1, MAX_PLY - 1);
-        m_StartTime = std::chrono::steady_clock::now();
+        if (m_WorkerIndex != 0)
+            m_StartTime = std::chrono::steady_clock::now();
         m_Aborted = false;
         m_Nodes = 0;
+        m_UnflushedNodes = 0;
         m_SelectiveDepth = 0;
         m_PvLength.fill(0);
-        m_TranspositionTable.NewSearch();
         for (auto& side : m_History)
         {
             for (auto& from : side)
@@ -77,6 +199,8 @@ namespace NeraChessSearch
             result.completed = true;
             result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - m_StartTime);
+            FlushNodeCount();
+            result.nodes = AggregateNodeCount();
             return result;
         }
 
@@ -94,6 +218,8 @@ namespace NeraChessSearch
             result.completed = true;
             result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - m_StartTime);
+            FlushNodeCount();
+            result.nodes = AggregateNodeCount();
             return result;
         }
         Score previousScore = SCORE_DRAW;
@@ -132,9 +258,9 @@ namespace NeraChessSearch
             result.principalVariation.assign(m_PvTable[0].begin(),
                 m_PvTable[0].begin() + m_PvLength[0]);
             previousScore = iteration.score;
-            result.nodes = m_Nodes;
+            result.nodes = AggregateNodeCount();
             result.selectiveDepth = m_SelectiveDepth;
-            result.hashFullPermill = m_TranspositionTable.HashFullPermill();
+            result.hashFullPermill = m_TranspositionTable->HashFullPermill();
             result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - m_StartTime);
             if (m_Limits.iterationCallback)
@@ -147,9 +273,10 @@ namespace NeraChessSearch
                 break;
         }
 
-        result.nodes = m_Nodes;
+        FlushNodeCount();
+        result.nodes = AggregateNodeCount();
         result.selectiveDepth = m_SelectiveDepth;
-        result.hashFullPermill = m_TranspositionTable.HashFullPermill();
+        result.hashFullPermill = m_TranspositionTable->HashFullPermill();
         result.aborted = m_Aborted;
         result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - m_StartTime);
@@ -167,9 +294,19 @@ namespace NeraChessSearch
             if (IsRootMoveAllowed(move))
                 moves.push(move);
         }
-        const TTEntry* ttEntry = m_TranspositionTable.Probe(board.GetZobristKey());
+        const std::optional<TTEntry> ttEntry =
+            m_TranspositionTable->Probe(board.GetZobristKey());
         const Move ttMove = ttEntry ? Move(ttEntry->move) : Move(0);
         SortMoves(board, moves, 0, ttMove);
+        if (m_WorkerIndex > 0 && moves.size() > 2)
+        {
+            // Preserve the strongest candidate while making helpers explore the rest
+            // of the root in different orders and feed those results into the shared TT.
+            const size_t rotation = 1 +
+                (m_WorkerIndex + static_cast<size_t>(depth)) % (moves.size() - 1);
+            if (rotation > 1)
+                std::rotate(moves.begin() + 1, moves.begin() + rotation, moves.end());
+        }
 
         m_PvLength[0] = 0;
         bool firstMove = true;
@@ -217,7 +354,7 @@ namespace NeraChessSearch
             bound = TTBound::Lower;
         if (m_Limits.rootMoves.empty() && board.GetHalfMoveClock() < 90)
         {
-            m_TranspositionTable.Store(board.GetZobristKey(), ScoreToTT(result.score, 0),
+            m_TranspositionTable->Store(board.GetZobristKey(), ScoreToTT(result.score, 0),
                 depth, bound, result.move);
         }
         return result;
@@ -230,7 +367,7 @@ namespace NeraChessSearch
         if (ShouldStop())
             return SCORE_DRAW;
 
-        ++m_Nodes;
+        CountNode();
         m_SelectiveDepth = std::max(m_SelectiveDepth, ply);
         m_PvLength[ply] = ply;
 
@@ -249,7 +386,7 @@ namespace NeraChessSearch
 
         const uint64_t key = board.GetZobristKey();
         const bool ttScoreUsable = board.GetHalfMoveClock() < 90;
-        const TTEntry* ttEntry = m_TranspositionTable.Probe(key);
+        const std::optional<TTEntry> ttEntry = m_TranspositionTable->Probe(key);
         Move ttMove = 0;
         if (ttEntry)
         {
@@ -295,7 +432,7 @@ namespace NeraChessSearch
                 {
                     if (ttScoreUsable)
                     {
-                        m_TranspositionTable.Store(key, ScoreToTT(beta, ply), depth,
+                        m_TranspositionTable->Store(key, ScoreToTT(beta, ply), depth,
                             TTBound::Lower, ttMove);
                     }
                     return beta;
@@ -411,7 +548,7 @@ namespace NeraChessSearch
         else if (bestScore >= beta)
             bound = TTBound::Lower;
         if (ttScoreUsable)
-            m_TranspositionTable.Store(key, ScoreToTT(bestScore, ply), depth, bound, bestMove);
+            m_TranspositionTable->Store(key, ScoreToTT(bestScore, ply), depth, bound, bestMove);
         return bestScore;
     }
 
@@ -420,7 +557,7 @@ namespace NeraChessSearch
         if (ShouldStop())
             return SCORE_DRAW;
 
-        ++m_Nodes;
+        CountNode();
         m_SelectiveDepth = std::max(m_SelectiveDepth, ply);
         m_PvLength[ply] = ply;
 
@@ -437,7 +574,7 @@ namespace NeraChessSearch
 
         const uint64_t key = board.GetZobristKey();
         const bool ttScoreUsable = board.GetHalfMoveClock() < 90;
-        const TTEntry* ttEntry = m_TranspositionTable.Probe(key);
+        const std::optional<TTEntry> ttEntry = m_TranspositionTable->Probe(key);
         Move ttMove = 0;
         if (ttEntry)
         {
@@ -467,7 +604,7 @@ namespace NeraChessSearch
             {
                 if (ttScoreUsable)
                 {
-                    m_TranspositionTable.Store(key, ScoreToTT(bestScore, ply), 0,
+                    m_TranspositionTable->Store(key, ScoreToTT(bestScore, ply), 0,
                         TTBound::Lower, ttMove);
                 }
                 return bestScore;
@@ -522,7 +659,7 @@ namespace NeraChessSearch
             {
                 if (ttScoreUsable)
                 {
-                    m_TranspositionTable.Store(key, ScoreToTT(bestScore, ply), 0,
+                    m_TranspositionTable->Store(key, ScoreToTT(bestScore, ply), 0,
                         TTBound::Lower, bestMove);
                 }
                 return bestScore;
@@ -531,7 +668,7 @@ namespace NeraChessSearch
 
         const TTBound bound = bestScore <= originalAlpha ? TTBound::Upper : TTBound::Exact;
         if (ttScoreUsable)
-            m_TranspositionTable.Store(key, ScoreToTT(bestScore, ply), 0, bound, bestMove);
+            m_TranspositionTable->Store(key, ScoreToTT(bestScore, ply), 0, bound, bestMove);
         return bestScore;
     }
 
@@ -601,23 +738,50 @@ namespace NeraChessSearch
         m_PvLength[ply] = childLength;
     }
 
+    void SearchEngine::CountNode()
+    {
+        // Batching avoids an atomic increment at every node. The global node limit
+        // can overshoot by at most one partial batch per worker.
+        constexpr uint64_t NodeFlushInterval = 256;
+        ++m_Nodes;
+        ++m_UnflushedNodes;
+        if (m_UnflushedNodes >= NodeFlushInterval)
+            FlushNodeCount();
+    }
+
+    void SearchEngine::FlushNodeCount()
+    {
+        if (m_UnflushedNodes == 0)
+            return;
+        m_SharedState->nodes.fetch_add(m_UnflushedNodes, std::memory_order_relaxed);
+        m_UnflushedNodes = 0;
+    }
+
+    uint64_t SearchEngine::AggregateNodeCount() const
+    {
+        return m_SharedState->nodes.load(std::memory_order_relaxed) + m_UnflushedNodes;
+    }
+
     bool SearchEngine::ShouldStop()
     {
         if (m_Aborted)
             return true;
-        if (m_StopRequested)
+        if (m_SharedState->stopRequested.load(std::memory_order_relaxed) ||
+            m_SharedState->searchStopped.load(std::memory_order_relaxed))
         {
             m_Aborted = true;
             return true;
         }
-        if (m_Limits.maxNodes > 0 && m_Nodes >= m_Limits.maxNodes)
+        if (m_Limits.maxNodes > 0 && AggregateNodeCount() >= m_Limits.maxNodes)
         {
+            m_SharedState->searchStopped = true;
             m_Aborted = true;
             return true;
         }
         if (m_Limits.hardTime.count() > 0 && (m_Nodes & 1023) == 0 &&
             TimeControlElapsed() >= m_Limits.hardTime)
         {
+            m_SharedState->searchStopped = true;
             m_Aborted = true;
             return true;
         }
@@ -626,7 +790,8 @@ namespace NeraChessSearch
 
     std::chrono::milliseconds SearchEngine::TimeControlElapsed() const
     {
-        const int64_t start = m_TimeControlStartMilliseconds.load();
+        const int64_t start =
+            m_SharedState->timeControlStartMilliseconds.load(std::memory_order_relaxed);
         if (start < 0)
             return std::chrono::milliseconds{ 0 };
         return std::chrono::milliseconds{ std::max<int64_t>(0, SteadyMilliseconds() - start) };

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <vector>
 
 namespace NeraChessSearch
@@ -49,21 +50,36 @@ namespace NeraChessSearch
         explicit SearchEngine(size_t hashMegabytes = 64);
 
         SearchResult Search(const NeraChessEngine::ChessBoard& position, const SearchLimits& limits);
-        void RequestStop() { m_StopRequested = true; }
+        void RequestStop() { m_SharedState->stopRequested = true; }
         void PrepareSearch(bool pondering = false);
         void PonderHit();
         void NewGame();
-        void ResizeHash(size_t megabytes) { m_TranspositionTable.Resize(megabytes); }
+        void ResizeHash(size_t megabytes);
+        void SetThreadCount(size_t threadCount);
+        size_t GetThreadCount() const { return m_ThreadCount; }
 
         static Score Evaluate(const NeraChessEngine::ChessBoard& board);
 
     private:
+        struct SharedSearchState
+        {
+            std::atomic<bool> stopRequested{ false };
+            std::atomic<bool> searchStopped{ false };
+            std::atomic<int64_t> timeControlStartMilliseconds{ 0 };
+            std::atomic<uint64_t> nodes{ 0 };
+        };
+
         struct RootResult
         {
             NeraChessEngine::Move move = 0;
             Score score = -SCORE_INF;
         };
 
+        SearchEngine(size_t workerIndex,
+            std::shared_ptr<TranspositionTable> transpositionTable,
+            std::shared_ptr<SharedSearchState> sharedState);
+        SearchResult SearchWorker(const NeraChessEngine::ChessBoard& position,
+            const SearchLimits& limits);
         RootResult SearchRoot(NeraChessEngine::ChessBoard& board, int depth, Score alpha, Score beta);
         Score PrincipalVariationSearch(NeraChessEngine::ChessBoard& board,
             Score alpha, Score beta, int depth, int ply, bool pvNode, bool allowNull,
@@ -74,6 +90,10 @@ namespace NeraChessSearch
             NeraChessEngine::MoveList<218>& moves, int ply, NeraChessEngine::Move ttMove,
             NeraChessEngine::Move previousMove = 0);
         void UpdatePrincipalVariation(int ply, NeraChessEngine::Move move);
+        void ResetHeuristics();
+        void CountNode();
+        void FlushNodeCount();
+        uint64_t AggregateNodeCount() const;
 
         bool ShouldStop();
         bool IsDrawOrTerminal(const NeraChessEngine::ChessBoard& board, Score& terminalScore, int ply) const;
@@ -91,14 +111,17 @@ namespace NeraChessSearch
         static int64_t SteadyMilliseconds();
 
     private:
-        TranspositionTable m_TranspositionTable;
+        std::shared_ptr<TranspositionTable> m_TranspositionTable;
+        std::shared_ptr<SharedSearchState> m_SharedState;
+        std::vector<std::unique_ptr<SearchEngine>> m_HelperEngines;
+        size_t m_ThreadCount = 1;
+        size_t m_WorkerIndex = 0;
         SearchLimits m_Limits;
         std::chrono::steady_clock::time_point m_StartTime;
-        std::atomic<bool> m_StopRequested{ false };
         std::atomic<bool> m_TimeControlPrepared{ false };
-        std::atomic<int64_t> m_TimeControlStartMilliseconds{ 0 };
         bool m_Aborted = false;
         uint64_t m_Nodes = 0;
+        uint64_t m_UnflushedNodes = 0;
         int m_SelectiveDepth = 0;
 
         std::array<std::array<NeraChessEngine::Move, 2>, MAX_PLY> m_KillerMoves{};

--- a/NeraChessSearch/src/TranspositionTable.cpp
+++ b/NeraChessSearch/src/TranspositionTable.cpp
@@ -5,6 +5,11 @@
 
 namespace NeraChessSearch
 {
+    namespace
+    {
+        constexpr uint64_t WriteLockedValidation = std::numeric_limits<uint64_t>::max();
+    }
+
     TranspositionTable::TranspositionTable(size_t megabytes)
     {
         Resize(megabytes);
@@ -21,16 +26,23 @@ namespace NeraChessSearch
     void TranspositionTable::Resize(size_t megabytes)
     {
         const size_t requestedBytes = std::max<size_t>(1, megabytes) * 1024ULL * 1024ULL;
-        const size_t requestedClusters = std::max<size_t>(1, requestedBytes / sizeof(TTCluster));
-        const size_t clusterCount = FloorPowerOfTwo(requestedClusters);
-        m_Clusters.assign(clusterCount, TTCluster{});
-        m_Mask = clusterCount - 1;
+        const size_t requestedClusters = std::max<size_t>(1, requestedBytes / sizeof(Cluster));
+        m_ClusterCount = FloorPowerOfTwo(requestedClusters);
+        m_Clusters = std::make_unique<Cluster[]>(m_ClusterCount);
+        m_Mask = m_ClusterCount - 1;
         m_Generation = 1;
     }
 
     void TranspositionTable::Clear()
     {
-        std::fill(m_Clusters.begin(), m_Clusters.end(), TTCluster{});
+        for (size_t clusterIndex = 0; clusterIndex < m_ClusterCount; ++clusterIndex)
+        {
+            for (AtomicEntry& entry : m_Clusters[clusterIndex].entries)
+            {
+                entry.payload.store(0, std::memory_order_relaxed);
+                entry.validation.store(0, std::memory_order_relaxed);
+            }
+        }
     }
 
     void TranspositionTable::NewSearch()
@@ -40,15 +52,88 @@ namespace NeraChessSearch
             m_Generation = 1;
     }
 
-    const TTEntry* TranspositionTable::Probe(uint64_t key) const
+    uint64_t TranspositionTable::Encode(const TTEntry& entry)
     {
-        const TTCluster& cluster = m_Clusters[key & m_Mask];
-        for (const TTEntry& entry : cluster.entries)
+        return static_cast<uint64_t>(entry.move) |
+            (static_cast<uint64_t>(static_cast<uint16_t>(entry.score)) << 32) |
+            (static_cast<uint64_t>(static_cast<uint8_t>(entry.depth)) << 48) |
+            (static_cast<uint64_t>(entry.generationAndBound) << 56);
+    }
+
+    bool TranspositionTable::IsPayloadValid(uint64_t payload)
+    {
+        return static_cast<TTBound>((payload >> 56) & 0x3) != TTBound::None;
+    }
+
+    TTEntry TranspositionTable::Decode(uint64_t key, uint64_t payload)
+    {
+        TTEntry entry;
+        entry.key = key;
+        entry.move = static_cast<uint32_t>(payload);
+        entry.score = static_cast<int16_t>(payload >> 32);
+        entry.depth = static_cast<int8_t>(payload >> 48);
+        entry.generationAndBound = static_cast<uint8_t>(payload >> 56);
+        return entry;
+    }
+
+    TranspositionTable::EntrySnapshot TranspositionTable::LoadSnapshot(
+        const AtomicEntry& entry)
+    {
+        EntrySnapshot snapshot;
+        const uint64_t firstValidation = entry.validation.load(std::memory_order_acquire);
+        if (firstValidation == WriteLockedValidation)
+            return snapshot;
+        const uint64_t payload = entry.payload.load(std::memory_order_acquire);
+        const uint64_t secondValidation = entry.validation.load(std::memory_order_acquire);
+        if (firstValidation != secondValidation)
+            return snapshot;
+        snapshot.validation = firstValidation;
+        snapshot.stable = true;
+        if (IsPayloadValid(payload))
+            snapshot.entry = Decode(firstValidation ^ payload, payload);
+        return snapshot;
+    }
+
+    std::optional<TTEntry> TranspositionTable::LoadEntry(
+        const AtomicEntry& entry, uint64_t key)
+    {
+        const EntrySnapshot snapshot = LoadSnapshot(entry);
+        if (!snapshot.stable || !snapshot.entry || snapshot.entry->key != key)
+            return std::nullopt;
+        return snapshot.entry;
+    }
+
+    bool TranspositionTable::LockEntry(AtomicEntry& entry, uint64_t expectedValidation)
+    {
+        if (expectedValidation == WriteLockedValidation)
+            return false;
+        return entry.validation.compare_exchange_strong(expectedValidation, WriteLockedValidation,
+            std::memory_order_acquire, std::memory_order_relaxed);
+    }
+
+    void TranspositionTable::PublishLocked(AtomicEntry& destination, const TTEntry& entry,
+        uint64_t previousValidation)
+    {
+        const uint64_t payload = Encode(entry);
+        const uint64_t validation = entry.key ^ payload;
+        if (validation == WriteLockedValidation)
         {
-            if (entry.IsValid() && entry.key == key)
-                return &entry;
+            destination.validation.store(previousValidation, std::memory_order_release);
+            return;
         }
-        return nullptr;
+        destination.payload.store(payload, std::memory_order_release);
+        destination.validation.store(validation, std::memory_order_release);
+    }
+
+    std::optional<TTEntry> TranspositionTable::Probe(uint64_t key) const
+    {
+        const Cluster& cluster = m_Clusters[key & m_Mask];
+        for (const AtomicEntry& entry : cluster.entries)
+        {
+            if (const std::optional<TTEntry> candidate = LoadEntry(entry, key))
+                return candidate;
+        }
+        return std::nullopt;
     }
 
     uint8_t TranspositionTable::MakeMetadata(TTBound bound) const
@@ -68,67 +153,106 @@ namespace NeraChessSearch
     void TranspositionTable::Store(uint64_t key, int score, int depth, TTBound bound,
         NeraChessEngine::Move bestMove)
     {
-        TTCluster& cluster = m_Clusters[key & m_Mask];
-        TTEntry* replacement = nullptr;
+        if (bound == TTBound::None)
+            return;
+        Cluster& cluster = m_Clusters[key & m_Mask];
+        AtomicEntry* exact = nullptr;
+        uint64_t exactValidation = 0;
+        AtomicEntry* empty = nullptr;
+        uint64_t emptyValidation = 0;
+        AtomicEntry* victim = nullptr;
+        uint64_t victimValidation = 0;
+        int victimQuality = std::numeric_limits<int>::max();
 
-        for (TTEntry& entry : cluster.entries)
+        for (AtomicEntry& atomicEntry : cluster.entries)
         {
-            if (entry.IsValid() && entry.key == key)
+            const EntrySnapshot snapshot = LoadSnapshot(atomicEntry);
+            if (!snapshot.stable)
+                continue;
+            if (snapshot.entry && snapshot.entry->key == key)
             {
-                const int oldQuality = static_cast<int>(entry.depth) +
-                    (entry.GetBound() == TTBound::Exact ? 4 : 0);
-                const int newQuality = depth + (bound == TTBound::Exact ? 4 : 0);
-                if (newQuality >= oldQuality)
-                {
-                    replacement = &entry;
-                }
-                else
-                {
-                    if (bestMove != 0)
-                        entry.move = bestMove;
-                    entry.generationAndBound = static_cast<uint8_t>(
-                        (m_Generation << 2) | static_cast<uint8_t>(entry.GetBound()));
-                    return;
-                }
+                exact = &atomicEntry;
+                exactValidation = snapshot.validation;
                 break;
             }
-            if (!entry.IsValid())
+            if (!snapshot.entry && !empty)
             {
-                replacement = &entry;
-                break;
+                empty = &atomicEntry;
+                emptyValidation = snapshot.validation;
+            }
+            if (snapshot.entry)
+            {
+                const int quality = EntryQuality(*snapshot.entry, m_Generation);
+                if (!victim || quality < victimQuality)
+                {
+                    victim = &atomicEntry;
+                    victimValidation = snapshot.validation;
+                    victimQuality = quality;
+                }
             }
         }
 
-        if (!replacement)
-        {
-            replacement = &cluster.entries[0];
-            for (TTEntry& entry : cluster.entries)
-            {
-                if (EntryQuality(entry, m_Generation) < EntryQuality(*replacement, m_Generation))
-                    replacement = &entry;
-            }
-        }
+        AtomicEntry* replacement = exact ? exact : (empty ? empty : victim);
+        const uint64_t replacementValidation = exact
+            ? exactValidation
+            : (empty ? emptyValidation : victimValidation);
 
-        replacement->key = key;
-        replacement->move = bestMove;
-        replacement->score = static_cast<int16_t>(std::clamp(score,
-            static_cast<int>(std::numeric_limits<int16_t>::min()),
-            static_cast<int>(std::numeric_limits<int16_t>::max())));
-        replacement->depth = static_cast<int8_t>(std::clamp(depth, -1, 127));
-        replacement->generationAndBound = MakeMetadata(bound);
+        if (!replacement || !LockEntry(*replacement, replacementValidation))
+            return;
+
+        const uint64_t currentPayload = replacement->payload.load(std::memory_order_acquire);
+        const std::optional<TTEntry> current = IsPayloadValid(currentPayload)
+            ? std::optional<TTEntry>{
+                Decode(replacementValidation ^ currentPayload, currentPayload) }
+            : std::nullopt;
+
+        TTEntry entry;
+        const int newQuality = depth + (bound == TTBound::Exact ? 4 : 0);
+        const int oldQuality = current && current->key == key
+            ? static_cast<int>(current->depth) +
+                (current->GetBound() == TTBound::Exact ? 4 : 0)
+            : std::numeric_limits<int>::min();
+        if (current && current->key == key && newQuality < oldQuality)
+        {
+            entry = *current;
+            if (bestMove != 0)
+                entry.move = bestMove;
+            entry.generationAndBound = static_cast<uint8_t>(
+                (m_Generation << 2) | static_cast<uint8_t>(entry.GetBound()));
+        }
+        else
+        {
+            entry.key = key;
+            entry.move = bestMove;
+            entry.score = static_cast<int16_t>(std::clamp(score,
+                static_cast<int>(std::numeric_limits<int16_t>::min()),
+                static_cast<int>(std::numeric_limits<int16_t>::max())));
+            entry.depth = static_cast<int8_t>(std::clamp(depth, -1, 127));
+            entry.generationAndBound = MakeMetadata(bound);
+        }
+        PublishLocked(*replacement, entry, replacementValidation);
     }
 
     int TranspositionTable::HashFullPermill() const
     {
-        if (m_Clusters.empty())
+        if (m_ClusterCount == 0)
             return 0;
-        const size_t sampleClusters = std::min<size_t>(m_Clusters.size(), 250);
+        const size_t sampleClusters = std::min<size_t>(m_ClusterCount, 250);
         size_t used = 0;
         for (size_t i = 0; i < sampleClusters; ++i)
         {
-            for (const TTEntry& entry : m_Clusters[i].entries)
-                used += entry.IsValid() && entry.GetGeneration() == m_Generation;
+            for (const AtomicEntry& atomicEntry : m_Clusters[i].entries)
+            {
+                const EntrySnapshot snapshot = LoadSnapshot(atomicEntry);
+                used += snapshot.entry &&
+                    snapshot.entry->GetGeneration() == m_Generation;
+            }
         }
         return static_cast<int>(used * 1000 / (sampleClusters * 4));
+    }
+
+    size_t TranspositionTable::SizeBytes() const
+    {
+        return m_ClusterCount * sizeof(Cluster);
     }
 }

--- a/NeraChessSearch/src/TranspositionTable.h
+++ b/NeraChessSearch/src/TranspositionTable.h
@@ -2,9 +2,11 @@
 
 #include "Move.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <vector>
+#include <memory>
+#include <optional>
 
 namespace NeraChessSearch
 {
@@ -16,7 +18,7 @@ namespace NeraChessSearch
         Upper = 3,
     };
 
-    struct alignas(16) TTEntry
+    struct TTEntry
     {
         uint64_t key = 0;
         uint32_t move = 0;
@@ -29,37 +31,65 @@ namespace NeraChessSearch
         bool IsValid() const { return GetBound() != TTBound::None; }
     };
 
-    struct alignas(64) TTCluster
-    {
-        TTEntry entries[4];
-    };
-
     static_assert(sizeof(TTEntry) == 16);
-    static_assert(sizeof(TTCluster) == 64);
 
     class TranspositionTable
     {
     public:
         explicit TranspositionTable(size_t megabytes = 64);
 
+        // The search coordinator calls these only while no worker is accessing the table.
         void Resize(size_t megabytes);
         void Clear();
         void NewSearch();
 
-        const TTEntry* Probe(uint64_t key) const;
+        std::optional<TTEntry> Probe(uint64_t key) const;
         void Store(uint64_t key, int score, int depth, TTBound bound,
             NeraChessEngine::Move bestMove);
 
         int HashFullPermill() const;
-        size_t SizeBytes() const { return m_Clusters.size() * sizeof(TTCluster); }
+        size_t SizeBytes() const;
 
     private:
+        struct alignas(16) AtomicEntry
+        {
+            // A committed entry satisfies validation == zobristKey ^ payload.
+            std::atomic<uint64_t> validation{ 0 };
+            std::atomic<uint64_t> payload{ 0 };
+        };
+
+        struct alignas(64) Cluster
+        {
+            AtomicEntry entries[4];
+        };
+
+        struct EntrySnapshot
+        {
+            uint64_t validation = 0;
+            std::optional<TTEntry> entry;
+            bool stable = false;
+        };
+
+        static_assert(sizeof(AtomicEntry) == 16);
+        static_assert(sizeof(Cluster) == 64);
+        static_assert(std::atomic<uint64_t>::is_always_lock_free,
+            "The shared transposition table requires lock-free 64-bit atomics");
+
         static size_t FloorPowerOfTwo(size_t value);
         static int EntryQuality(const TTEntry& entry, uint8_t currentGeneration);
+        static bool IsPayloadValid(uint64_t payload);
+        static uint64_t Encode(const TTEntry& entry);
+        static TTEntry Decode(uint64_t key, uint64_t payload);
+        static EntrySnapshot LoadSnapshot(const AtomicEntry& entry);
+        static std::optional<TTEntry> LoadEntry(const AtomicEntry& entry, uint64_t key);
+        static bool LockEntry(AtomicEntry& entry, uint64_t expectedValidation);
+        static void PublishLocked(AtomicEntry& destination, const TTEntry& entry,
+            uint64_t previousValidation);
         uint8_t MakeMetadata(TTBound bound) const;
 
     private:
-        std::vector<TTCluster> m_Clusters;
+        std::unique_ptr<Cluster[]> m_Clusters;
+        size_t m_ClusterCount = 0;
         size_t m_Mask = 0;
         uint8_t m_Generation = 1;
     };

--- a/NeraChessTests/Build-NeraChessTests.lua
+++ b/NeraChessTests/Build-NeraChessTests.lua
@@ -26,6 +26,8 @@ project "NeraChessTests"
 
   filter "system:windows"
     systemversion "latest"
+  filter "system:linux"
+    links { "pthread" }
   filter {}
 
   filter "configurations:Debug"

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -8,13 +8,18 @@
 #include "Zobrist.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <exception>
 #include <iostream>
+#include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace
@@ -268,25 +273,113 @@ namespace
 
         TranspositionTable table(1);
         Require(table.SizeBytes() <= 1024ULL * 1024ULL, "TT exceeded requested size");
-        Require(table.Probe(0) == nullptr, "empty TT reported a key-zero hit");
+        Require(!table.Probe(0), "empty TT reported a key-zero hit");
 
         table.NewSearch();
         table.Store(0, 42, 8, TTBound::Exact, NeraChessEngine::Move(123));
-        const TTEntry* zeroEntry = table.Probe(0);
+        const std::optional<TTEntry> zeroEntry = table.Probe(0);
         Require(zeroEntry && zeroEntry->score == 42 && zeroEntry->depth == 8,
             "TT failed to store key zero");
 
         constexpr uint64_t key = 0x123456789ABCDEF0ULL;
         table.Store(key, 300, 12, TTBound::Exact, NeraChessEngine::Move(456));
         table.Store(key, -50, 2, TTBound::Upper, NeraChessEngine::Move(789));
-        const TTEntry* preserved = table.Probe(key);
+        const std::optional<TTEntry> preserved = table.Probe(key);
         Require(preserved && preserved->score == 300 && preserved->depth == 12 &&
             preserved->GetBound() == TTBound::Exact,
             "shallow TT bound replaced a deep exact entry");
         Require(preserved->move == 789, "TT did not refresh the best move");
 
         table.Clear();
-        Require(table.Probe(key) == nullptr, "TT clear left a valid entry");
+        Require(!table.Probe(key), "TT clear left a valid entry");
+    }
+
+    void TestConcurrentTranspositionTable()
+    {
+        using namespace NeraChessSearch;
+
+        TranspositionTable table(1);
+        table.NewSearch();
+        const uint64_t clusterCount = table.SizeBytes() / 64;
+        constexpr size_t WorkerCount = 8;
+        constexpr int Iterations = 20'000;
+        std::atomic<bool> failed{ false };
+        std::atomic<uint64_t> successfulProbes{ 0 };
+        std::vector<std::jthread> workers;
+        workers.reserve(WorkerCount);
+
+        for (size_t worker = 0; worker < WorkerCount; ++worker)
+        {
+            workers.emplace_back([&, worker]
+            {
+                const uint64_t key = 0x1234ULL + worker * clusterCount;
+                const int score = static_cast<int>(worker * 37) - 100;
+                const int depth = static_cast<int>(worker) + 1;
+                const NeraChessEngine::Move move(static_cast<uint32_t>(worker + 1));
+                for (int iteration = 0; iteration < Iterations; ++iteration)
+                {
+                    table.Store(key, score, depth, TTBound::Exact, move);
+                    const std::optional<TTEntry> entry = table.Probe(key);
+                    if (entry)
+                    {
+                        ++successfulProbes;
+                        if (entry->key != key || entry->move != move ||
+                            entry->score != score || entry->depth != depth ||
+                            entry->GetBound() != TTBound::Exact)
+                        {
+                            failed = true;
+                            return;
+                        }
+                    }
+                    if ((iteration & 255) == 0)
+                        static_cast<void>(table.HashFullPermill());
+                }
+            });
+        }
+        for (std::jthread& worker : workers)
+            worker.join();
+        Require(!failed, "concurrent TT probe accepted a torn or mismatched entry");
+        Require(successfulProbes.load() > 100,
+            "concurrent TT stress produced no meaningful successful probes");
+
+        TranspositionTable sameKeyTable(1);
+        sameKeyTable.NewSearch();
+        constexpr uint64_t SharedKey = 0xFEDCBA9876543210ULL;
+        const NeraChessEngine::Move FirstMove(101);
+        const NeraChessEngine::Move SecondMove(202);
+        std::atomic<uint64_t> sameKeyHits{ 0 };
+        failed = false;
+        workers.clear();
+        for (size_t worker = 0; worker < WorkerCount; ++worker)
+        {
+            workers.emplace_back([&, worker]
+            {
+                const bool firstTuple = (worker & 1) == 0;
+                const NeraChessEngine::Move move = firstTuple ? FirstMove : SecondMove;
+                const int score = firstTuple ? 111 : -222;
+                for (int iteration = 0; iteration < Iterations; ++iteration)
+                {
+                    sameKeyTable.Store(SharedKey, score, 9, TTBound::Exact, move);
+                    const std::optional<TTEntry> entry = sameKeyTable.Probe(SharedKey);
+                    if (!entry)
+                        continue;
+                    ++sameKeyHits;
+                    const bool firstValid = entry->move == FirstMove && entry->score == 111;
+                    const bool secondValid = entry->move == SecondMove && entry->score == -222;
+                    if ((!firstValid && !secondValid) || entry->depth != 9 ||
+                        entry->GetBound() != TTBound::Exact)
+                    {
+                        failed = true;
+                        return;
+                    }
+                }
+            });
+        }
+        for (std::jthread& worker : workers)
+            worker.join();
+        Require(!failed, "same-key TT stress accepted a cross-published payload");
+        Require(sameKeyHits.load() > 100,
+            "same-key TT stress produced no meaningful successful probes");
     }
 
     bool ContainsMove(const NeraChessEngine::MoveList<218>& moves, NeraChessEngine::Move move)
@@ -388,6 +481,115 @@ namespace
         const SearchResult draw = search.Search(nearDraw, limits);
         Require(draw.score == SCORE_DRAW,
             "transposition score bypassed the approaching 50-move draw");
+    }
+
+    void TestMultithreadedSearch()
+    {
+        using namespace NeraChessEngine;
+        using namespace NeraChessSearch;
+
+        SearchEngine search(32);
+        search.SetThreadCount(4);
+        Require(search.GetThreadCount() == 4, "search did not retain its thread count");
+
+        ChessBoard board("r1bq1rk1/pp2bppp/2n1pn2/2pp4/3P4/2PBPN2/PP1N1PPP/R1BQ1RK1 w - - 4 9");
+        const ChessBoard original = board;
+        SearchLimits limits;
+        limits.maxDepth = 5;
+        const std::thread::id caller = std::this_thread::get_id();
+        std::vector<int> callbackDepths;
+        limits.iterationCallback = [&](const SearchResult& iteration)
+        {
+            Require(std::this_thread::get_id() == caller,
+                "helper worker invoked the iteration callback");
+            callbackDepths.push_back(iteration.completedDepth);
+        };
+
+        const SearchResult result = search.Search(board, limits);
+        Require(result.completedDepth == limits.maxDepth && !result.aborted,
+            "multithreaded search did not complete its requested depth");
+        Require(ContainsMove(board.GetLegalMoves(), result.bestMove),
+            "multithreaded search returned an illegal move");
+        Require(!result.principalVariation.empty() &&
+            result.principalVariation.front() == result.bestMove,
+            "multithreaded search returned an inconsistent principal variation");
+        Require(board == original, "multithreaded search mutated its input board");
+        Require(callbackDepths.size() == static_cast<size_t>(result.completedDepth),
+            "helper workers emitted callbacks or an iteration callback was lost");
+        for (size_t index = 0; index < callbackDepths.size(); ++index)
+        {
+            Require(callbackDepths[index] == static_cast<int>(index + 1),
+                "multithreaded iteration callbacks were out of order");
+        }
+
+        search.NewGame();
+        ChessBoard mateInOne("7k/5Q2/6K1/8/8/8/8/8 w - - 0 1");
+        SearchLimits mateLimits;
+        mateLimits.maxDepth = 2;
+        const SearchResult mate = search.Search(mateInOne, mateLimits);
+        mateInOne.MakeMove(mate.bestMove);
+        Require((mateInOne.GetGameOver() & IS_CHECKMATE) != 0,
+            "multithreaded search missed mate in one");
+
+        search.NewGame();
+        ChessBoard start;
+        SearchLimits restricted;
+        restricted.maxDepth = 4;
+        restricted.rootMoves.push_back(FindMove(start, "e2e4"));
+        Require(search.Search(start, restricted).bestMove == restricted.rootMoves.front(),
+            "multithreaded search ignored its root-move restriction");
+
+        search.NewGame();
+        SearchLimits nodeLimited;
+        nodeLimited.maxDepth = 30;
+        nodeLimited.maxNodes = 20'000;
+        const SearchResult limited = search.Search(start, nodeLimited);
+        Require(limited.aborted, "aggregate multithreaded node limit did not stop search");
+        Require(limited.nodes >= nodeLimited.maxNodes &&
+            limited.nodes <= nodeLimited.maxNodes + search.GetThreadCount() * 256,
+            "multithreaded node accounting did not enforce one aggregate budget");
+
+        search.NewGame();
+        SearchLimits stoppedLimits;
+        stoppedLimits.maxDepth = 30;
+        std::mutex depthMutex;
+        std::condition_variable depthCondition;
+        int reachedDepth = 0;
+        stoppedLimits.iterationCallback = [&](const SearchResult& iteration)
+        {
+            {
+                std::scoped_lock lock(depthMutex);
+                reachedDepth = iteration.completedDepth;
+            }
+            depthCondition.notify_one();
+        };
+        SearchResult stoppedResult;
+        std::jthread searching([&]
+        {
+            stoppedResult = search.Search(start, stoppedLimits);
+        });
+        std::unique_lock depthLock(depthMutex);
+        const bool startedPromptly = depthCondition.wait_for(depthLock,
+            std::chrono::seconds{ 2 }, [&] { return reachedDepth >= 2; });
+        depthLock.unlock();
+        search.RequestStop();
+        searching.join();
+        Require(startedPromptly, "multithreaded search did not start promptly");
+        Require(stoppedResult.aborted &&
+            ContainsMove(start.GetLegalMoves(), stoppedResult.bestMove),
+            "external stop did not preserve a legal completed multithreaded result");
+
+        search.NewGame();
+        search.SetThreadCount(2);
+        search.ResizeHash(8);
+        search.SetThreadCount(1);
+        Require(search.GetThreadCount() == 1,
+            "search thread-count lifecycle did not return to one worker");
+        SearchLimits lifecycleLimits;
+        lifecycleLimits.maxDepth = 2;
+        Require(ContainsMove(start.GetLegalMoves(),
+            search.Search(start, lifecycleLimits).bestMove),
+            "search failed after thread-count and hash reconfiguration");
     }
 
     void TestTaperedEvaluation()
@@ -586,6 +788,45 @@ namespace
                       << '\n';
         }
     }
+
+    void RunThreadBenchmark()
+    {
+        using namespace NeraChessSearch;
+
+        static constexpr std::string_view positions[] = {
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            "r1bq1rk1/pp2bppp/2n1pn2/2pp4/3P4/2PBPN2/PP1N1PPP/R1BQ1RK1 w - - 4 9",
+        };
+
+        for (const size_t threadCount : { 1ULL, 2ULL, 4ULL })
+        {
+            SearchEngine search(256);
+            search.SetThreadCount(threadCount);
+            for (size_t positionIndex = 0; positionIndex < std::size(positions); ++positionIndex)
+            {
+                search.NewGame();
+                ChessBoard board{ std::string(positions[positionIndex]) };
+                SearchLimits limits;
+                limits.maxDepth = MAX_PLY - 1;
+                limits.softTime = std::chrono::milliseconds{ 750 };
+                limits.hardTime = std::chrono::milliseconds{ 800 };
+                const SearchResult result = search.Search(board, limits);
+                const double seconds = std::max(0.001,
+                    std::chrono::duration<double>(result.elapsed).count());
+                std::cout << "threadbench threads " << threadCount
+                          << " position " << positionIndex
+                          << " depth " << result.completedDepth
+                          << " seldepth " << result.selectiveDepth
+                          << " score " << result.score
+                          << " bestmove " << result.bestMove.ToUCI()
+                          << " nodes " << result.nodes
+                          << " time " << result.elapsed.count()
+                          << " nps " << static_cast<uint64_t>(result.nodes / seconds)
+                          << '\n';
+            }
+        }
+    }
 }
 
 int main(int argc, char** argv)
@@ -602,6 +843,11 @@ int main(int argc, char** argv)
             RunSearchBenchmark();
             return 0;
         }
+        if (argc == 2 && std::string_view(argv[1]) == "--thread-bench")
+        {
+            RunThreadBenchmark();
+            return 0;
+        }
 
         TestFenValidation();
         TestPerft();
@@ -611,8 +857,10 @@ int main(int argc, char** argv)
         TestIncrementalZobrist();
         TestNullMoveState();
         TestTranspositionTable();
+        TestConcurrentTranspositionTable();
         TestSearchFoundations();
         TestFiftyMoveTranspositions();
+        TestMultithreadedSearch();
         TestTaperedEvaluation();
         TestSearchChoices();
         TestStaticExchangeEvaluation();

--- a/NeraChessUCI/src/UciSession.cpp
+++ b/NeraChessUCI/src/UciSession.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -91,6 +92,7 @@ bool UciSession::HandleCommand(const std::string& line)
         Print("id name NeraChess");
         Print("id author Raphael Hounsiagaman");
         Print("option name Hash type spin default 64 min 1 max 1024");
+        Print("option name Threads type spin default 1 min 1 max 256");
         Print("option name Clear Hash type button");
         Print("option name OwnBook type check default true");
         Print("option name BookFile type string default " + m_OpeningBookPath.string());
@@ -173,6 +175,22 @@ void UciSession::SetOption(std::string_view command)
     {
         if (const auto megabytes = ParseNumber<int>(value))
             m_SearchEngine.ResizeHash(static_cast<size_t>(std::clamp(*megabytes, 1, 1024)));
+    }
+    else if (name == "Threads")
+    {
+        if (const auto threadCount = ParseNumber<int>(value))
+        {
+            try
+            {
+                m_SearchEngine.SetThreadCount(
+                    static_cast<size_t>(std::clamp(*threadCount, 1, 256)));
+            }
+            catch (const std::exception& exception)
+            {
+                Print("info string unable to configure Threads: " +
+                    std::string(exception.what()));
+            }
+        }
     }
     else if (name == "Clear Hash")
     {
@@ -405,7 +423,31 @@ void UciSession::StartSearch(std::string_view command)
     m_SearchThread = std::jthread([this, position = std::move(position),
         limits = std::move(limits), pondering]() mutable
     {
-        const NeraChessSearch::SearchResult result = m_SearchEngine.Search(position, limits);
+        NeraChessSearch::SearchResult result;
+        try
+        {
+            result = m_SearchEngine.Search(position, limits);
+        }
+        catch (const std::exception& exception)
+        {
+            Print("info string search failed: " + std::string(exception.what()));
+            for (const NeraChessEngine::Move move : position.GetLegalMoves())
+            {
+                result.bestMove = move;
+                break;
+            }
+            result.aborted = true;
+        }
+        catch (...)
+        {
+            Print("info string search failed with an unknown error");
+            for (const NeraChessEngine::Move move : position.GetLegalMoves())
+            {
+                result.bestMove = move;
+                break;
+            }
+            result.aborted = true;
+        }
         std::unique_lock lock(m_PonderMutex);
         if (pondering)
         {

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The main goals of this project are:
 
 - Principal Variation Search (PVS)
 - Iterative Deepening
+- Lazy SMP search with a configurable shared transposition table
 - Aspiration windows and mate-distance pruning
 - Alpha-Beta Pruning
 - Clustered transposition table with configurable size
@@ -131,8 +132,19 @@ UCI-compatible chess GUI:
 
 It supports standard position setup, `go` depth/node/time limits,
 `searchmoves`, asynchronous `stop`, `ponder`/`ponderhit`, hash sizing and
-clearing, `OwnBook`, `BookFile`, and `Ponder` options, bundled opening-book
-play, and iterative `info` output.
+clearing, configurable `Threads`, `OwnBook`, `BookFile`, and `Ponder` options,
+bundled opening-book play, and iterative `info` output.
+
+NeraChess defaults to one UCI search thread for reproducible engine matches.
+Configure additional workers with the standard option, for example:
+
+```text
+setoption name Threads value 4
+```
+
+Workers keep private boards and move-ordering heuristics while sharing a
+concurrency-safe transposition table and one aggregate time/node budget. The
+desktop bot automatically uses up to four hardware threads.
 
 When `Ponder` is enabled, normal searches include the predicted opponent reply
 in `bestmove ... ponder ...` when one is available. A `go ponder` search remains
@@ -223,18 +235,22 @@ opening-book index:
 ./bin/Release/NeraChessTests/NeraChessTests
 ```
 
-Two deterministic benchmark modes are also available:
+Deterministic perft/search benchmarks and a fixed-time thread-scaling benchmark
+are also available:
 
 ```sh
 ./bin/Release/NeraChessTests/NeraChessTests --bench
 ./bin/Release/NeraChessTests/NeraChessTests --search-bench
+./bin/Release/NeraChessTests/NeraChessTests --thread-bench
 ```
+
+`--thread-bench` is a quick, scheduling-sensitive scaling diagnostic rather
+than a reproducible Elo measurement.
 
 ---
 
 ## Known Limitations
 
-- No multi-threaded search.
 - Evaluation parameters are hand-tuned rather than trained from games.
 
 ---

--- a/scripts/Test-UciPonder.py
+++ b/scripts/Test-UciPonder.py
@@ -96,7 +96,10 @@ def run_test(executable: Path) -> None:
             option_lines.append(line)
         if "option name Ponder type check default false" not in option_lines:
             raise AssertionError("engine did not advertise the standard Ponder option")
+        if "option name Threads type spin default 1 min 1 max 256" not in option_lines:
+            raise AssertionError("engine did not advertise the standard Threads option")
 
+        engine.send("setoption name Threads value 4")
         engine.send("setoption name Ponder value true")
         engine.send("isready")
         engine.wait_for(lambda line: line == "readyok", "readyok")
@@ -155,6 +158,30 @@ def run_test(executable: Path) -> None:
         engine.send("go depth 3")
         engine.wait_for(lambda line: line.startswith("bestmove "), "bestmove after stopped ponder")
         engine.assert_no_bestmove(0.1)
+
+        engine.send("position startpos")
+        engine.send("go infinite")
+        engine.wait_for(
+            lambda line: line.startswith("info depth 2 "),
+            "multithreaded infinite search progress",
+        )
+        engine.send("stop")
+        engine.wait_for(
+            lambda line: line.startswith("bestmove "),
+            "multithreaded infinite-search bestmove",
+        )
+        engine.assert_no_bestmove(0.1)
+
+        engine.send("position startpos")
+        engine.send("go infinite")
+        engine.send("setoption name Threads value 2")
+        engine.wait_for(
+            lambda line: line.startswith("bestmove "),
+            "bestmove while changing thread count",
+        )
+        engine.send("setoption name Threads value 4")
+        engine.send("isready")
+        engine.wait_for(lambda line: line == "readyok", "readyok after thread-count change")
 
         engine.send("position startpos")
         engine.send("go ponder searchmoves a1a1")


### PR DESCRIPTION
## Summary

- add Lazy SMP search workers with private board and move-ordering state
- share stop, time, node accounting, and a concurrency-safe transposition table
- diversify helper root ordering while keeping worker 0 authoritative
- expose the standard UCI `Threads` option and enable up to four threads in the desktop bot
- expand multithreaded, UCI, sanitizer, and benchmark coverage

## Why

NeraChess's UCI adapter was asynchronous, but the actual tree search remained single-threaded. Search state and the transposition table were mutable and unsafe to access concurrently, so simply launching several searches would have introduced data races and duplicated node budgets.

This change separates coordinator and worker state, validates atomic TT snapshots, aggregates limits across workers, and preserves deterministic one-thread behavior.

## User impact

UCI users can configure workers with:

```text
setoption name Threads value 4
```

The desktop bot automatically uses up to four hardware threads.

A fixed-time release benchmark on the development machine measured approximately 3.8–4.1x aggregate NPS with four threads. Two of the three benchmark positions completed two additional plies, while the third matched the one-thread depth. This demonstrates throughput and depth improvement, not a statistically measured Elo gain.

## Validation

- Debug and Release engine regression suites
- repeated four-thread search regressions
- concurrent TT collision and same-key publication stress
- aggregate node-limit, external-stop, root restriction, mate, and lifecycle tests
- UCI pondering, infinite search, stop, and live thread-option changes
- desktop smoke and clock-smoke tests
- AddressSanitizer and UndefinedBehaviorSanitizer
- ThreadSanitizer for the search core and UCI lifecycle
- one-thread fixed-depth node counts unchanged
- `git diff --check`
