### PR TITLE
Replace fixed LMR ladder with log-based reductions

### DIFF
--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -19,6 +19,39 @@ namespace NeraChessSearch
     namespace
     {
         constexpr std::array<int, 6> PieceValues = { 100, 320, 330, 500, 900, 0 };
+
+        // Late move reductions are accumulated in 1/1024 of a ply so that the base
+        // curve and the individual adjustments can stay fractional, and only the
+        // final sum is truncated to whole plies.
+        constexpr int REDUCTION_SCALE = 1024;
+        constexpr int MAX_REDUCTION_DEPTH = 64;
+        constexpr int MAX_REDUCTION_MOVES = 64;
+
+        // Base curve: 0.85 + ln(depth) * ln(moveIndex) / 2.35. The logarithmic shape
+        // keeps early moves at shallow depths almost unreduced while letting late
+        // moves at high depths be cut hard, which the previous fixed ladder (capped
+        // at three plies regardless of depth) could not express.
+        struct ReductionTable
+        {
+            std::array<std::array<int16_t, MAX_REDUCTION_MOVES>, MAX_REDUCTION_DEPTH> values{};
+
+            ReductionTable()
+            {
+                for (int depth = 1; depth < MAX_REDUCTION_DEPTH; ++depth)
+                {
+                    for (int moveIndex = 1; moveIndex < MAX_REDUCTION_MOVES; ++moveIndex)
+                    {
+                        const double reduction = 0.85 +
+                            std::log(static_cast<double>(depth)) *
+                            std::log(static_cast<double>(moveIndex)) / 2.35;
+                        values[depth][moveIndex] = static_cast<int16_t>(
+                            std::lround(reduction * REDUCTION_SCALE));
+                    }
+                }
+            }
+        };
+
+        const ReductionTable Reductions;
     }
 
     SearchEngine::SearchEngine(size_t hashMegabytes)
@@ -90,6 +123,7 @@ namespace NeraChessSearch
         m_CounterMoves = {};
         m_PvTable = {};
         m_PvLength = {};
+        m_StaticEvals.fill(SCORE_NONE);
     }
 
     SearchResult SearchEngine::Search(const ChessBoard& position, const SearchLimits& limits)
@@ -181,6 +215,7 @@ namespace NeraChessSearch
         m_UnflushedNodes = 0;
         m_SelectiveDepth = 0;
         m_PvLength.fill(0);
+        m_StaticEvals.fill(SCORE_NONE);
         for (auto& side : m_History)
         {
             for (auto& from : side)
@@ -317,15 +352,15 @@ namespace NeraChessSearch
             if (firstMove)
             {
                 score = -PrincipalVariationSearch(board, -beta, -alpha,
-                    depth - 1, 1, true, true, move);
+                    depth - 1, 1, true, true, move, false);
             }
             else
             {
                 score = -PrincipalVariationSearch(board, -alpha - 1, -alpha,
-                    depth - 1, 1, false, true, move);
+                    depth - 1, 1, false, true, move, true);
                 if (!m_Aborted && score > alpha && score < beta)
                     score = -PrincipalVariationSearch(board, -beta, -alpha,
-                        depth - 1, 1, true, true, move);
+                        depth - 1, 1, true, true, move, false);
             }
             board.UndoMove(move);
 
@@ -362,7 +397,7 @@ namespace NeraChessSearch
 
     Score SearchEngine::PrincipalVariationSearch(ChessBoard& board,
         Score alpha, Score beta, int depth, int ply, bool pvNode, bool allowNull,
-        Move previousMove)
+        Move previousMove, bool cutNode)
     {
         if (ShouldStop())
             return SCORE_DRAW;
@@ -410,9 +445,26 @@ namespace NeraChessSearch
         const bool canFutilityPrune = !pvNode && !inCheck && !mateBounds && depth <= 2;
         const bool canNullPrune = allowNull && !pvNode && !inCheck && !mateBounds &&
             depth >= 3 && HasNonPawnMaterial(board);
+        // The static evaluation is now kept for every non-check node so that the
+        // improving flag (this side is better than it was two plies ago) is available
+        // to late move reductions instead of only to the pruning heuristics.
         Score staticEval = SCORE_DRAW;
-        if (canReverseFutility || canFutilityPrune || canNullPrune)
+        bool improving = false;
+        if (inCheck)
+        {
+            m_StaticEvals[ply] = SCORE_NONE;
+        }
+        else
+        {
             staticEval = Evaluate(board);
+            m_StaticEvals[ply] = staticEval;
+            if (ply >= 2 && m_StaticEvals[ply - 2] != SCORE_NONE)
+                improving = staticEval > m_StaticEvals[ply - 2];
+            else if (ply >= 4 && m_StaticEvals[ply - 4] != SCORE_NONE)
+                improving = staticEval > m_StaticEvals[ply - 4];
+            else
+                improving = true;
+        }
 
         if (canReverseFutility && staticEval - 120 * depth >= beta)
             return staticEval;
@@ -423,7 +475,7 @@ namespace NeraChessSearch
             {
                 const int reduction = 2 + depth / 4;
                 const Score nullScore = -PrincipalVariationSearch(board, -beta, -beta + 1,
-                    depth - 1 - reduction, ply + 1, false, false, 0);
+                    depth - 1 - reduction, ply + 1, false, false, 0, !cutNode);
                 board.UndoNullMove();
 
                 if (m_Aborted)
@@ -470,28 +522,39 @@ namespace NeraChessSearch
             Score score;
             if (firstMove)
             {
+                // The first child of a principal variation node is itself a
+                // principal variation node; elsewhere cut and all nodes alternate.
                 score = -PrincipalVariationSearch(board, -beta, -alpha,
-                    depth - 1, ply + 1, pvNode, true, move);
+                    depth - 1, ply + 1, pvNode, true, move, pvNode ? false : !cutNode);
             }
             else
             {
                 int reduction = 0;
-                if (depth >= 3 && moveIndex >= 3 && quiet && !killer && !counter &&
+                // Killers and countermoves are no longer exempt: their history is
+                // already high, so the history term inside LateMoveReduction gives
+                // them a smaller reduction instead of none at all. Reductions now
+                // start one move earlier outside the principal variation.
+                if (depth >= 3 && moveIndex >= (pvNode ? 3 : 2) && quiet &&
                     !inCheck && !givesCheck)
                 {
-                    reduction = LateMoveReduction(depth, moveIndex, pvNode);
+                    int32_t historyScore =
+                        m_History[side][move.GetStartSquare()][move.GetTargetSquare()];
+                    if (killer || counter)
+                        historyScore = std::max(historyScore, MAX_HISTORY / 2);
+                    reduction = LateMoveReduction(depth, moveIndex, pvNode, improving,
+                        cutNode, ttMove != 0, historyScore);
                 }
 
                 score = -PrincipalVariationSearch(board, -alpha - 1, -alpha,
-                    depth - 1 - reduction, ply + 1, false, true, move);
+                    depth - 1 - reduction, ply + 1, false, true, move, true);
                 if (!m_Aborted && reduction > 0 && score > alpha)
                 {
                     score = -PrincipalVariationSearch(board, -alpha - 1, -alpha,
-                        depth - 1, ply + 1, false, true, move);
+                        depth - 1, ply + 1, false, true, move, !cutNode);
                 }
                 if (!m_Aborted && pvNode && score > alpha && score < beta)
                     score = -PrincipalVariationSearch(board, -beta, -alpha,
-                        depth - 1, ply + 1, true, true, move);
+                        depth - 1, ply + 1, true, true, move, false);
             }
             board.UndoMove(move);
 
@@ -857,15 +920,37 @@ namespace NeraChessSearch
         return true;
     }
 
-    int SearchEngine::LateMoveReduction(int depth, int moveIndex, bool pvNode)
+    int SearchEngine::LateMoveReduction(int depth, int moveIndex, bool pvNode, bool improving,
+        bool cutNode, bool ttMove, int32_t historyScore)
     {
-        int reduction = 1;
-        if (depth >= 6)
-            ++reduction;
-        if (moveIndex >= 8)
-            ++reduction;
+        const int tableDepth = std::clamp(depth, 1, MAX_REDUCTION_DEPTH - 1);
+        const int tableMove = std::clamp(moveIndex, 1, MAX_REDUCTION_MOVES - 1);
+        int reduction = Reductions.values[tableDepth][tableMove];
+
+        // Principal variation nodes carry the game continuation, so keep them shallow.
         if (pvNode)
-            --reduction;
+            reduction -= REDUCTION_SCALE;
+        // Expected fail-high nodes are the cheapest place to be aggressive.
+        if (cutNode)
+            reduction += 3 * REDUCTION_SCALE / 2;
+        // A rising static evaluation means the line is worth another look.
+        if (improving)
+            reduction -= REDUCTION_SCALE;
+        // A transposition-table move means the node was searched before and its
+        // ordering is trustworthy, so the tail of the move list is more likely junk.
+        if (ttMove)
+            reduction += REDUCTION_SCALE / 2;
+
+        // History steers the reduction continuously instead of relying only on the
+        // killer/countermove exemptions: quiets that repeatedly cut are reduced up
+        // to two plies less, quiets that repeatedly fail are reduced up to two more.
+        reduction -= std::clamp(historyScore, -MAX_HISTORY, MAX_HISTORY) *
+            (2 * REDUCTION_SCALE) / MAX_HISTORY;
+
+        reduction /= REDUCTION_SCALE;
+
+        // Never reduce into quiescence: the re-search that verifies a raised alpha
+        // has to be strictly deeper than the reduced search for LMR to stay sound.
         return std::clamp(reduction, 0, depth - 2);
     }
 
@@ -895,9 +980,8 @@ namespace NeraChessSearch
 
     void SearchEngine::UpdateHistoryScore(int32_t& score, int bonus)
     {
-        constexpr int MaxHistory = 16'384;
-        bonus = std::clamp(bonus, -MaxHistory, MaxHistory);
-        score += bonus - score * std::abs(bonus) / MaxHistory;
+        bonus = std::clamp(bonus, -MAX_HISTORY, MAX_HISTORY);
+        score += bonus - score * std::abs(bonus) / MAX_HISTORY;
     }
 
     Score SearchEngine::Evaluate(const ChessBoard& board)

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -18,7 +18,11 @@ namespace NeraChessSearch
     inline constexpr Score SCORE_INF = 32'000;
     inline constexpr Score SCORE_MATE = 30'000;
     inline constexpr Score SCORE_DRAW = 0;
+    // Sentinel for "no static evaluation is available at this ply", used by the
+    // improving heuristic when a node was searched while in check.
+    inline constexpr Score SCORE_NONE = 32'001;
     inline constexpr int MAX_PLY = 128;
+    inline constexpr int MAX_HISTORY = 16'384;
 
     struct SearchResult
     {
@@ -83,7 +87,7 @@ namespace NeraChessSearch
         RootResult SearchRoot(NeraChessEngine::ChessBoard& board, int depth, Score alpha, Score beta);
         Score PrincipalVariationSearch(NeraChessEngine::ChessBoard& board,
             Score alpha, Score beta, int depth, int ply, bool pvNode, bool allowNull,
-            NeraChessEngine::Move previousMove);
+            NeraChessEngine::Move previousMove, bool cutNode);
         Score QuiescenceSearch(NeraChessEngine::ChessBoard& board, Score alpha, Score beta, int ply);
 
         void SortMoves(const NeraChessEngine::ChessBoard& board,
@@ -102,7 +106,8 @@ namespace NeraChessSearch
         static int PieceValue(NeraChessEngine::Piece piece);
         static bool IsQuiet(NeraChessEngine::Move move);
         static bool IsFutilityPrunable(NeraChessEngine::Move move);
-        static int LateMoveReduction(int depth, int moveIndex, bool pvNode);
+        static int LateMoveReduction(int depth, int moveIndex, bool pvNode, bool improving,
+            bool cutNode, bool ttMove, int32_t historyScore);
         static bool HasNonPawnMaterial(const NeraChessEngine::ChessBoard& board);
         bool IsRootMoveAllowed(NeraChessEngine::Move move) const;
         NeraChessEngine::Move GetCounterMove(NeraChessEngine::Move previousMove) const;
@@ -129,5 +134,6 @@ namespace NeraChessSearch
         std::array<std::array<NeraChessEngine::Move, 64>, 12> m_CounterMoves{};
         std::array<std::array<NeraChessEngine::Move, MAX_PLY>, MAX_PLY> m_PvTable{};
         std::array<int, MAX_PLY> m_PvLength{};
+        std::array<Score, MAX_PLY> m_StaticEvals{};
     };
 }


### PR DESCRIPTION
## Summary

Replaces the fixed late-move-reduction ladder with a logarithmic reduction curve plus
per-node adjustments, so the amount a late quiet move is reduced now scales with depth
instead of saturating at three plies.

The old ladder was `1 + (depth >= 6) + (moveIndex >= 8) - pvNode`, clamped to a maximum of
three plies. Because both terms were step functions, every node past depth 6 and move 8
received the same reduction whether it was depth 8 or depth 30 — the search could not be
more selective as it got deeper, which is exactly where selectivity pays.

## What changed

**Logarithmic base curve.** `0.85 + ln(depth) * ln(moveIndex) / 2.35`, precomputed once
into a 64x64 table. Reductions are accumulated in 1/1024 of a ply so the base curve and
every adjustment stay fractional, and only the final sum is truncated to whole plies.

Resulting reduction for a late quiet move at a non-PV cut node, compared with the old ladder:

| depth | move | old ladder | new (base) | new (cut node) |
|------:|-----:|-----------:|-----------:|---------------:|
| 4     | 4    | 1          | 1.67       | 2              |
| 8     | 8    | 3          | 2.69       | 4              |
| 16    | 16   | 3 (capped) | 4.12       | 5              |
| 32    | 32   | 3 (capped) | 5.96       | 7              |

Shallow and early moves are reduced about as much as before; the change is concentrated in
the deep tail, where the old cap was doing the most damage.

**Per-node adjustments**, applied fractionally before truncation:

- `-1.0` at PV nodes — they carry the game continuation, keep them shallow.
- `+1.5` at cut nodes — expected fail-highs are the cheapest place to be aggressive.
- `-1.0` when improving — a rising static eval means the line deserves another look.
- `+0.5` when a TT move exists — the node was searched before, so its ordering is
  trustworthy and the tail of the move list is likelier to be junk.
- `+/-2.0` from butterfly history, continuous.

**Cut-node tracking.** `PrincipalVariationSearch` takes a `cutNode` parameter, propagated
so that the first child of a PV node is a PV node and cut/all nodes alternate elsewhere.

**`improving` flag.** Static evaluations are now kept per ply in `m_StaticEvals` (with a
`SCORE_NONE` sentinel for in-check nodes, which have no meaningful static eval) and
compared against the value two plies back, falling back to four.

**Killers and countermoves are no longer exempt from reduction.** Their history is already
high, so instead of skipping LMR entirely they get a history floor of `MAX_HISTORY / 2`,
which the continuous history term turns into a smaller reduction rather than none at all.
Reductions also start one move earlier outside the PV (`moveIndex >= 2` rather than `>= 3`).

`MAX_HISTORY` moved from a function-local constant in `UpdateHistoryScore` to a header
constant, since LMR now scales against the same bound.

## Verification

- `NeraChessTests` passes in Release (`All NeraChess engine tests passed.`).
- Release builds clean via `./scripts/Setup-macOS.sh gmake && make config=release`.
- UCI smoke test on a middlegame position (book off, 64 MiB hash, 3 s) searches to depth 14
  with a sane PV and reports `bestmove c3b5`.

**Self-play validation is still outstanding.** CONTRIBUTING asks for a game sample rather
than an estimated rating on anything that changes playing strength, and this has not yet
been run through a paired-opening match against the pre-change binary. The change should be
measured before merging — a reduction curve that is too aggressive tends to look good on
depth and bad on results, and depth alone will not catch that.

## Risks and things worth a close look

- **Static eval is now computed at every non-check node.** Previously it was computed only
  when reverse futility, futility, or null-move pruning needed it. The `improving` flag
  needs it everywhere, so nodes that previously skipped evaluation now pay for it. This is a
  real cost that the self-play match needs to clear.
- Removing the killer/countermove exemption is the riskiest single piece here — it is a
  behavior change independent of the curve, and it may be worth measuring separately.
- `std::clamp(reduction, 0, depth - 2)` still guarantees the reduced search stays strictly
  shallower than the verification re-search and never drops into quiescence.
