### PR TITLE
Replace the shallow pruning layer with a depth-scaled selective search

### DIFF
--- a/NeraChessEngine/src/ChessBoard.cpp
+++ b/NeraChessEngine/src/ChessBoard.cpp
@@ -978,5 +978,105 @@ namespace NeraChessEngine
 		return m_MoveGenerator.InCheck();
 	}
 
+	bool ChessBoard::GivesCheck(Move move) const
+	{
+		const Piece movePiece = move.GetMovePiece();
+		const bool whitesMove = movePiece.IsWhite();
+		const uint8_t offset = whitesMove ? 0 : 6;
+		const uint8_t enemyOffset = whitesMove ? 6 : 0;
+
+		const Bitboard enemyKing = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_KING];
+		if (!enemyKing)
+			return false;
+		const uint8_t enemyKingSquare = BitUtil::GetLSBIndex(enemyKing);
+
+		const uint8_t startSquare = move.GetStartSquare();
+		const uint8_t targetSquare = move.GetTargetSquare();
+		const uint8_t moveFlags = move.GetMoveFlags();
+
+		Bitboard occupancy = 0;
+		for (const Bitboard pieceSet : m_BoardState.pieceBitboards)
+			occupancy |= pieceSet;
+
+		// Replay the move on local copies of only the boards that can change: the
+		// occupancy, the friendly attackers, and the castling rook.
+		Bitboard pawns = m_BoardState.pieceBitboards[offset + PieceType::WHITE_PAWN];
+		Bitboard knights = m_BoardState.pieceBitboards[offset + PieceType::WHITE_KNIGHT];
+		Bitboard bishops = m_BoardState.pieceBitboards[offset + PieceType::WHITE_BISHOP];
+		Bitboard rooks = m_BoardState.pieceBitboards[offset + PieceType::WHITE_ROOK];
+		Bitboard queens = m_BoardState.pieceBitboards[offset + PieceType::WHITE_QUEEN];
+
+		const Bitboard startBitboard = s_SquareBitboard[startSquare];
+		const Bitboard targetBitboard = s_SquareBitboard[targetSquare];
+		occupancy &= ~startBitboard;
+		occupancy |= targetBitboard;
+
+		if (moveFlags & MoveFlags::IS_EN_PASSANT)
+		{
+			const uint8_t capturedSquare = whitesMove
+				? static_cast<uint8_t>(targetSquare - 8)
+				: static_cast<uint8_t>(targetSquare + 8);
+			occupancy &= ~s_SquareBitboard[capturedSquare];
+		}
+		else if (moveFlags & MoveFlags::IS_CASTLES)
+		{
+			const bool queenSide = Square(targetSquare).GetFile() == 2;
+			const uint8_t rookFrom = whitesMove ? (queenSide ? 0 : 7) : (queenSide ? 56 : 63);
+			const uint8_t rookTo = whitesMove ? (queenSide ? 3 : 5) : (queenSide ? 59 : 61);
+			occupancy &= ~s_SquareBitboard[rookFrom];
+			occupancy |= s_SquareBitboard[rookTo];
+			rooks &= ~s_SquareBitboard[rookFrom];
+			rooks |= s_SquareBitboard[rookTo];
+		}
+
+		const auto relocate = [&](Bitboard& board) { board &= ~startBitboard; };
+		relocate(pawns);
+		relocate(knights);
+		relocate(bishops);
+		relocate(rooks);
+		relocate(queens);
+
+		const uint8_t landedType = (moveFlags & MoveFlags::IS_PROMOTION)
+			? static_cast<uint8_t>(move.GetPromoPiece() % 6)
+			: static_cast<uint8_t>(movePiece % 6);
+		switch (landedType)
+		{
+		case PieceType::WHITE_PAWN:
+			pawns |= targetBitboard;
+			break;
+		case PieceType::WHITE_KNIGHT:
+			knights |= targetBitboard;
+			break;
+		case PieceType::WHITE_BISHOP:
+			bishops |= targetBitboard;
+			break;
+		case PieceType::WHITE_ROOK:
+			rooks |= targetBitboard;
+			break;
+		case PieceType::WHITE_QUEEN:
+			queens |= targetBitboard;
+			break;
+		default:
+			// A king can never give check itself, but it still blocks and unblocks rays,
+			// which the shared occupancy above already accounts for.
+			break;
+		}
+
+		// Testing attacks outward from the enemy king covers direct checks and
+		// discovered checks in the same pass.
+		const Bitboard pawnCheckers = whitesMove
+			? MoveGenerator::s_BlackPawnAttackMasks[enemyKingSquare]
+			: MoveGenerator::s_WhitePawnAttackMasks[enemyKingSquare];
+		if (pawnCheckers & pawns)
+			return true;
+		if (MoveGenerator::s_KnightMoveMask[enemyKingSquare] & knights)
+			return true;
+		if (MoveGenerator::LookupBishopAttacks(enemyKingSquare, occupancy) & (bishops | queens))
+			return true;
+		if (MoveGenerator::LookupRookAttacks(enemyKingSquare, occupancy) & (rooks | queens))
+			return true;
+		return false;
+	}
+
 
 } // namespace NeraChessEngine

--- a/NeraChessEngine/src/ChessBoard.h
+++ b/NeraChessEngine/src/ChessBoard.h
@@ -62,6 +62,13 @@ namespace NeraChessEngine
 
         Piece GetPiece(const uint8_t square) const;
         bool IsInCheck() const;
+
+	    // Reports whether a legal move would check the opponent, without making it.
+	    // Making the move and calling IsInCheck() answers the same question but forces
+	    // a full legal-move generation for the child position, which is wasted work for
+	    // a move the search is about to discard.
+	    bool GivesCheck(Move move) const;
+
         uint16_t GetGameOver(bool gameCheck = true) const;
 
         uint64_t GetZobristKey() const;

--- a/NeraChessEngine/src/MoveGenerator.cpp
+++ b/NeraChessEngine/src/MoveGenerator.cpp
@@ -1070,6 +1070,16 @@ namespace NeraChessEngine
 
 	}
 
+	Bitboard MoveGenerator::LookupRookAttacks(Square square, Bitboard occupancy)
+	{
+		return GetSlidingAttacks(square, occupancy, true);
+	}
+
+	Bitboard MoveGenerator::LookupBishopAttacks(Square square, Bitboard occupancy)
+	{
+		return GetSlidingAttacks(square, occupancy, false);
+	}
+
 	Bitboard MoveGenerator::GetSlidingAttacks(Square square, Bitboard blockers, bool orthogonal)
 	{
 		if (square >= 64)

--- a/NeraChessEngine/src/MoveGenerator.h
+++ b/NeraChessEngine/src/MoveGenerator.h
@@ -34,7 +34,7 @@ namespace NeraChessEngine
 
 		void GeneratePromotions(Square startSquare, Square targetSquare);
 
-		Bitboard GetSlidingAttacks(Square square, Bitboard blockers, bool orthogonal);
+		static Bitboard GetSlidingAttacks(Square square, Bitboard blockers, bool orthogonal);
 
 		Piece GetPiece(Square square);
 
@@ -133,6 +133,11 @@ namespace NeraChessEngine
 
 		static Bitboard CalculatePossibleRookMoves(Square from_square, Bitboard blockers);
 		static Bitboard CalculatePossibleBishopMoves(Square from_square, Bitboard blockers);
+
+		// CalculatePossible*Moves walks the ray and exists to build the magic tables.
+		// These are the constant-time lookups meant for use inside the search.
+		static Bitboard LookupRookAttacks(Square square, Bitboard occupancy);
+		static Bitboard LookupBishopAttacks(Square square, Bitboard occupancy);
 
 		static const std::unique_ptr<Bitboard[]> s_RookMoveMasksArray;
 		static const std::unique_ptr<Bitboard[]> s_BishopMoveMasksArray;

--- a/NeraChessSearch/src/MoveOrdering.cpp
+++ b/NeraChessSearch/src/MoveOrdering.cpp
@@ -38,8 +38,12 @@ namespace NeraChessSearch::MoveOrdering
             const Bitboard pawnAttackers = white
                 ? MoveGenerator::s_BlackPawnAttackMasks[target]
                 : MoveGenerator::s_WhitePawnAttackMasks[target];
-            const Bitboard diagonalAttacks = MoveGenerator::CalculatePossibleBishopMoves(target, occupancy);
-            const Bitboard straightAttacks = MoveGenerator::CalculatePossibleRookMoves(target, occupancy);
+            // The magic tables are built from CalculatePossible*Moves over every blocker
+            // subset, so these lookups return the same sets without walking the rays.
+            // Static exchange evaluation calls this once per attacker per capture, which
+            // makes it one of the hottest functions in move ordering.
+            const Bitboard diagonalAttacks = MoveGenerator::LookupBishopAttacks(target, occupancy);
+            const Bitboard straightAttacks = MoveGenerator::LookupRookAttacks(target, occupancy);
 
             return (pawnAttackers & pieces[offset + PieceType::WHITE_PAWN]) |
                 (MoveGenerator::s_KnightMoveMask[target] & pieces[offset + PieceType::WHITE_KNIGHT]) |

--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -20,38 +20,44 @@ namespace NeraChessSearch
     {
         constexpr std::array<int, 6> PieceValues = { 100, 320, 330, 500, 900, 0 };
 
-        // Late move reductions are accumulated in 1/1024 of a ply so that the base
-        // curve and the individual adjustments can stay fractional, and only the
-        // final sum is truncated to whole plies.
-        constexpr int REDUCTION_SCALE = 1024;
-        constexpr int MAX_REDUCTION_DEPTH = 64;
-        constexpr int MAX_REDUCTION_MOVES = 64;
+        // Selective-search tuning. Every margin is in centipawns and every depth is in
+        // plies. The values follow the usual published ranges; they were checked against
+        // the baseline with self-play rather than copied from another engine's tuning.
+        constexpr int ReverseFutilityMaxDepth = 7;
+        constexpr int ReverseFutilityMargin = 130;
+        constexpr int FutilityMaxDepth = 6;
+        constexpr int FutilityMargin = 90;
+        constexpr int FutilityBase = 70;
+        constexpr int LateMovePruningMaxDepth = 8;
+        constexpr int InternalIterativeReductionMinDepth = 4;
+        // Only the quiet moves that plausibly caused a cutoff need a history malus.
+        constexpr size_t MaxTrackedQuietMoves = 64;
 
-        // Base curve: 0.85 + ln(depth) * ln(moveIndex) / 2.35. The logarithmic shape
-        // keeps early moves at shallow depths almost unreduced while letting late
-        // moves at high depths be cut hard, which the previous fixed ladder (capped
-        // at three plies regardless of depth) could not express.
-        struct ReductionTable
+        // Late move reductions, indexed by remaining depth and move number. The
+        // logarithmic shape is what lets late quiet moves lose several plies at high
+        // depth while the first few moves stay nearly full depth.
+        constexpr int ReductionDepthLimit = 64;
+        constexpr int ReductionMoveLimit = 64;
+
+        std::array<std::array<int8_t, ReductionMoveLimit>, ReductionDepthLimit> BuildReductions()
         {
-            std::array<std::array<int16_t, MAX_REDUCTION_MOVES>, MAX_REDUCTION_DEPTH> values{};
-
-            ReductionTable()
+            std::array<std::array<int8_t, ReductionMoveLimit>, ReductionDepthLimit> table{};
+            for (int depth = 1; depth < ReductionDepthLimit; ++depth)
             {
-                for (int depth = 1; depth < MAX_REDUCTION_DEPTH; ++depth)
+                for (int moveNumber = 1; moveNumber < ReductionMoveLimit; ++moveNumber)
                 {
-                    for (int moveIndex = 1; moveIndex < MAX_REDUCTION_MOVES; ++moveIndex)
-                    {
-                        const double reduction = 0.85 +
-                            std::log(static_cast<double>(depth)) *
-                            std::log(static_cast<double>(moveIndex)) / 2.35;
-                        values[depth][moveIndex] = static_cast<int16_t>(
-                            std::lround(reduction * REDUCTION_SCALE));
-                    }
+                    const double reduction = 0.85 +
+                        std::log(static_cast<double>(depth)) *
+                            std::log(static_cast<double>(moveNumber)) / 2.30;
+                    table[depth][moveNumber] =
+                        static_cast<int8_t>(std::clamp(static_cast<int>(reduction), 0, 31));
                 }
             }
-        };
+            return table;
+        }
 
-        const ReductionTable Reductions;
+        const std::array<std::array<int8_t, ReductionMoveLimit>, ReductionDepthLimit> Reductions =
+            BuildReductions();
     }
 
     SearchEngine::SearchEngine(size_t hashMegabytes)
@@ -123,7 +129,7 @@ namespace NeraChessSearch
         m_CounterMoves = {};
         m_PvTable = {};
         m_PvLength = {};
-        m_StaticEvals.fill(SCORE_NONE);
+        m_StaticEval.fill(SCORE_NONE);
     }
 
     SearchResult SearchEngine::Search(const ChessBoard& position, const SearchLimits& limits)
@@ -215,7 +221,7 @@ namespace NeraChessSearch
         m_UnflushedNodes = 0;
         m_SelectiveDepth = 0;
         m_PvLength.fill(0);
-        m_StaticEvals.fill(SCORE_NONE);
+        m_StaticEval.fill(SCORE_NONE);
         for (auto& side : m_History)
         {
             for (auto& from : side)
@@ -344,6 +350,9 @@ namespace NeraChessSearch
         }
 
         m_PvLength[0] = 0;
+        // Seed the static-evaluation stack so the "improving" test is meaningful from
+        // ply 2 onwards instead of silently disabled for the first two plies.
+        m_StaticEval[0] = board.IsInCheck() ? SCORE_NONE : Evaluate(board);
         bool firstMove = true;
         for (const Move move : moves)
         {
@@ -441,56 +450,52 @@ namespace NeraChessSearch
         const bool inCheck = board.IsInCheck();
         const bool mateBounds = beta <= -SCORE_MATE + MAX_PLY ||
             beta >= SCORE_MATE - MAX_PLY;
-        const bool canReverseFutility = !pvNode && !inCheck && !mateBounds && depth <= 2;
-        const bool canFutilityPrune = !pvNode && !inCheck && !mateBounds && depth <= 2;
-        const bool canNullPrune = allowNull && !pvNode && !inCheck && !mateBounds &&
-            depth >= 3 && HasNonPawnMaterial(board);
-        // The static evaluation is now kept for every non-check node so that the
-        // improving flag (this side is better than it was two plies ago) is available
-        // to late move reductions instead of only to the pruning heuristics.
-        Score staticEval = SCORE_DRAW;
-        bool improving = false;
-        if (inCheck)
-        {
-            m_StaticEvals[ply] = SCORE_NONE;
-        }
-        else
-        {
-            staticEval = Evaluate(board);
-            m_StaticEvals[ply] = staticEval;
-            if (ply >= 2 && m_StaticEvals[ply - 2] != SCORE_NONE)
-                improving = staticEval > m_StaticEvals[ply - 2];
-            else if (ply >= 4 && m_StaticEvals[ply - 4] != SCORE_NONE)
-                improving = staticEval > m_StaticEvals[ply - 4];
-            else
-                improving = true;
-        }
 
-        if (canReverseFutility && staticEval - 120 * depth >= beta)
+        // The static evaluation of every ply is kept so a node can tell whether its own
+        // side is improving relative to two plies ago. Pruning margins and reductions
+        // are all conditioned on it: a position that is getting worse deserves a wider,
+        // more careful search than one that is getting better.
+        const Score staticEval = inCheck ? SCORE_NONE : Evaluate(board);
+        m_StaticEval[ply] = staticEval;
+        const bool improving = !inCheck && ply >= 2 &&
+            m_StaticEval[ply - 2] != SCORE_NONE && staticEval > m_StaticEval[ply - 2];
+        const bool canPrune = !pvNode && !inCheck && !mateBounds;
+
+        // Reverse futility: the side to move is so far ahead that even conceding
+        // ReverseFutilityMargin per remaining ply keeps it above beta.
+        if (canPrune && depth <= ReverseFutilityMaxDepth &&
+            staticEval - ReverseFutilityMargin * (depth - improving) >= beta)
+        {
             return staticEval;
+        }
 
-        if (canNullPrune)
+        if (allowNull && canPrune && depth >= 3 && HasNonPawnMaterial(board) &&
+            staticEval >= beta && board.MakeNullMove())
         {
-            if (staticEval >= beta && board.MakeNullMove())
-            {
-                const int reduction = 2 + depth / 4;
-                const Score nullScore = -PrincipalVariationSearch(board, -beta, -beta + 1,
-                    depth - 1 - reduction, ply + 1, false, false, 0, !cutNode);
-                board.UndoNullMove();
+            const int reduction = 3 + depth / 4 +
+                std::min(3, (staticEval - beta) / 200);
+            const Score nullScore = -PrincipalVariationSearch(board, -beta, -beta + 1,
+                depth - 1 - reduction, ply + 1, false, false, 0, !cutNode);
+            board.UndoNullMove();
 
-                if (m_Aborted)
-                    return SCORE_DRAW;
-                if (nullScore >= beta)
+            if (m_Aborted)
+                return SCORE_DRAW;
+            if (nullScore >= beta)
+            {
+                if (ttScoreUsable)
                 {
-                    if (ttScoreUsable)
-                    {
-                        m_TranspositionTable->Store(key, ScoreToTT(beta, ply), depth,
-                            TTBound::Lower, ttMove);
-                    }
-                    return beta;
+                    m_TranspositionTable->Store(key, ScoreToTT(beta, ply), depth,
+                        TTBound::Lower, ttMove);
                 }
+                return beta;
             }
         }
+
+        // Internal iterative reduction: a node deep enough to matter but with no stored
+        // move will order badly, so it is cheaper to search it a ply shallower and let
+        // the resulting entry order the re-search.
+        if (depth >= InternalIterativeReductionMinDepth && ttMove == 0 && (pvNode || cutNode))
+            --depth;
 
         const Score originalAlpha = alpha;
         MoveList<218> moves = board.GetLegalMoves();
@@ -498,10 +503,11 @@ namespace NeraChessSearch
 
         Score bestScore = -SCORE_INF;
         Move bestMove = 0;
-        std::array<Move, 218> quietMovesSearched{};
+        std::array<Move, MaxTrackedQuietMoves> quietMovesSearched;
         size_t quietMoveCount = 0;
         const Move counterMove = GetCounterMove(previousMove);
         const uint8_t side = board.GetBoardState().HasFlag(BoardStateFlags::WhiteToMove) ? 0 : 1;
+        const int lateMoveCountLimit = LateMoveCountLimit(depth, improving);
         bool firstMove = true;
         int moveIndex = 0;
         for (const Move move : moves)
@@ -510,40 +516,49 @@ namespace NeraChessSearch
             const bool killer = quiet &&
                 (move == m_KillerMoves[ply][0] || move == m_KillerMoves[ply][1]);
             const bool counter = quiet && move == counterMove;
-            board.MakeMove(move);
-            const bool givesCheck = board.IsInCheck();
-            if (canFutilityPrune && staticEval + 120 * depth <= alpha &&
-                bestMove != 0 && !killer && !counter && !givesCheck && IsFutilityPrunable(move))
+
+            // Everything below decides against a move without making it. The board is
+            // only touched once a move survives, which is what makes a wider pruning
+            // layer cheaper than the narrow one it replaces. Checking moves are always
+            // exempt: a quiet check is exactly the kind of move that decides a forced
+            // line, and it is also the kind that orders badly enough to be pruned.
+            bool givesCheck = false;
+            if (canPrune && quiet && bestScore > -SCORE_INF)
             {
-                board.UndoMove(move);
-                ++moveIndex;
-                continue;
+                const bool prunableByCount =
+                    depth <= LateMovePruningMaxDepth && moveIndex >= lateMoveCountLimit;
+                const bool prunableByMargin = depth <= FutilityMaxDepth && !killer && !counter &&
+                    staticEval + FutilityMargin * depth + FutilityBase <= alpha &&
+                    IsFutilityPrunable(move);
+                if (prunableByCount || prunableByMargin)
+                {
+                    givesCheck = board.GivesCheck(move);
+                    if (!givesCheck)
+                    {
+                        // Skipping rather than leaving the loop: killers and counter
+                        // moves sort ahead of losing captures, so breaking out here
+                        // would also discard captures that still have to be searched.
+                        ++moveIndex;
+                        continue;
+                    }
+                }
             }
+
+            board.MakeMove(move);
+            givesCheck = board.IsInCheck();
             Score score;
             if (firstMove)
             {
-                // The first child of a principal variation node is itself a
-                // principal variation node; elsewhere cut and all nodes alternate.
                 score = -PrincipalVariationSearch(board, -beta, -alpha,
                     depth - 1, ply + 1, pvNode, true, move, pvNode ? false : !cutNode);
             }
             else
             {
-                int reduction = 0;
-                // Killers and countermoves are no longer exempt: their history is
-                // already high, so the history term inside LateMoveReduction gives
-                // them a smaller reduction instead of none at all. Reductions now
-                // start one move earlier outside the principal variation.
-                if (depth >= 3 && moveIndex >= (pvNode ? 3 : 2) && quiet &&
-                    !inCheck && !givesCheck)
-                {
-                    int32_t historyScore =
-                        m_History[side][move.GetStartSquare()][move.GetTargetSquare()];
-                    if (killer || counter)
-                        historyScore = std::max(historyScore, MAX_HISTORY / 2);
-                    reduction = LateMoveReduction(depth, moveIndex, pvNode, improving,
-                        cutNode, ttMove != 0, historyScore);
-                }
+                const int reduction = quiet && !inCheck && !givesCheck
+                    ? LateMoveReduction(depth, moveIndex, pvNode, cutNode, improving,
+                        killer || counter,
+                        m_History[side][move.GetStartSquare()][move.GetTargetSquare()])
+                    : 0;
 
                 score = -PrincipalVariationSearch(board, -alpha - 1, -alpha,
                     depth - 1 - reduction, ply + 1, false, true, move, true);
@@ -561,7 +576,7 @@ namespace NeraChessSearch
             if (m_Aborted)
                 return SCORE_DRAW;
 
-            if (quiet)
+            if (quiet && quietMoveCount < quietMovesSearched.size())
                 quietMovesSearched[quietMoveCount++] = move;
 
             if (score > bestScore)
@@ -586,9 +601,11 @@ namespace NeraChessSearch
                     const int bonus = std::min(16'384, 32 * depth * depth);
                     UpdateHistoryScore(
                         m_History[side][move.GetStartSquare()][move.GetTargetSquare()], bonus);
-                    for (size_t index = 0; index + 1 < quietMoveCount; ++index)
+                    for (size_t index = 0; index < quietMoveCount; ++index)
                     {
                         const Move failed = quietMovesSearched[index];
+                        if (failed == move)
+                            continue;
                         UpdateHistoryScore(
                             m_History[side][failed.GetStartSquare()][failed.GetTargetSquare()],
                             -bonus / 2);
@@ -920,38 +937,32 @@ namespace NeraChessSearch
         return true;
     }
 
-    int SearchEngine::LateMoveReduction(int depth, int moveIndex, bool pvNode, bool improving,
-        bool cutNode, bool ttMove, int32_t historyScore)
+    int SearchEngine::LateMoveReduction(int depth, int moveIndex, bool pvNode, bool cutNode,
+        bool improving, bool orderedQuiet, int32_t historyScore)
     {
-        const int tableDepth = std::clamp(depth, 1, MAX_REDUCTION_DEPTH - 1);
-        const int tableMove = std::clamp(moveIndex, 1, MAX_REDUCTION_MOVES - 1);
-        int reduction = Reductions.values[tableDepth][tableMove];
+        if (depth < 3 || moveIndex < 3)
+            return 0;
 
-        // Principal variation nodes carry the game continuation, so keep them shallow.
+        int reduction = Reductions[std::min(depth, ReductionDepthLimit - 1)]
+                                  [std::min(moveIndex, ReductionMoveLimit - 1)];
         if (pvNode)
-            reduction -= REDUCTION_SCALE;
-        // Expected fail-high nodes are the cheapest place to be aggressive.
-        if (cutNode)
-            reduction += 3 * REDUCTION_SCALE / 2;
-        // A rising static evaluation means the line is worth another look.
+            --reduction;
         if (improving)
-            reduction -= REDUCTION_SCALE;
-        // A transposition-table move means the node was searched before and its
-        // ordering is trustworthy, so the tail of the move list is more likely junk.
-        if (ttMove)
-            reduction += REDUCTION_SCALE / 2;
-
-        // History steers the reduction continuously instead of relying only on the
-        // killer/countermove exemptions: quiets that repeatedly cut are reduced up
-        // to two plies less, quiets that repeatedly fail are reduced up to two more.
-        reduction -= std::clamp(historyScore, -MAX_HISTORY, MAX_HISTORY) *
-            (2 * REDUCTION_SCALE) / MAX_HISTORY;
-
-        reduction /= REDUCTION_SCALE;
-
-        // Never reduce into quiescence: the re-search that verifies a raised alpha
-        // has to be strictly deeper than the reduced search for LMR to stay sound.
+            --reduction;
+        if (orderedQuiet)
+            --reduction;
+        if (cutNode)
+            ++reduction;
+        // History is clamped to +/-16384, so this shifts the reduction by at most four
+        // plies either way based on how the move has actually performed.
+        reduction -= historyScore / 4096;
         return std::clamp(reduction, 0, depth - 2);
+    }
+
+    int SearchEngine::LateMoveCountLimit(int depth, bool improving)
+    {
+        const int limited = std::min(depth, LateMovePruningMaxDepth);
+        return (3 + limited * limited) / (improving ? 1 : 2);
     }
 
     bool SearchEngine::HasNonPawnMaterial(const ChessBoard& board)

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -18,8 +18,8 @@ namespace NeraChessSearch
     inline constexpr Score SCORE_INF = 32'000;
     inline constexpr Score SCORE_MATE = 30'000;
     inline constexpr Score SCORE_DRAW = 0;
-    // Sentinel for "no static evaluation is available at this ply", used by the
-    // improving heuristic when a node was searched while in check.
+    // Marks a ply whose static evaluation is unavailable because the side to move is
+    // in check. Kept outside the usable score range so it can never compare as a score.
     inline constexpr Score SCORE_NONE = 32'001;
     inline constexpr int MAX_PLY = 128;
     inline constexpr int MAX_HISTORY = 16'384;
@@ -106,8 +106,9 @@ namespace NeraChessSearch
         static int PieceValue(NeraChessEngine::Piece piece);
         static bool IsQuiet(NeraChessEngine::Move move);
         static bool IsFutilityPrunable(NeraChessEngine::Move move);
-        static int LateMoveReduction(int depth, int moveIndex, bool pvNode, bool improving,
-            bool cutNode, bool ttMove, int32_t historyScore);
+        static int LateMoveReduction(int depth, int moveIndex, bool pvNode, bool cutNode,
+            bool improving, bool orderedQuiet, int32_t historyScore);
+        static int LateMoveCountLimit(int depth, bool improving);
         static bool HasNonPawnMaterial(const NeraChessEngine::ChessBoard& board);
         bool IsRootMoveAllowed(NeraChessEngine::Move move) const;
         NeraChessEngine::Move GetCounterMove(NeraChessEngine::Move previousMove) const;
@@ -129,11 +130,11 @@ namespace NeraChessSearch
         uint64_t m_UnflushedNodes = 0;
         int m_SelectiveDepth = 0;
 
+        std::array<Score, MAX_PLY> m_StaticEval{};
         std::array<std::array<NeraChessEngine::Move, 2>, MAX_PLY> m_KillerMoves{};
         std::array<std::array<std::array<int32_t, 64>, 64>, 2> m_History{};
         std::array<std::array<NeraChessEngine::Move, 64>, 12> m_CounterMoves{};
         std::array<std::array<NeraChessEngine::Move, MAX_PLY>, MAX_PLY> m_PvTable{};
         std::array<int, MAX_PLY> m_PvLength{};
-        std::array<Score, MAX_PLY> m_StaticEvals{};
     };
 }

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -246,6 +246,46 @@ namespace
         }
     }
 
+    // ChessBoard::GivesCheck answers the same question as making the move and asking
+    // IsInCheck, so the two are compared exhaustively over every move of every position
+    // in a small tree. The search prunes on this predicate, so a disagreement would
+    // quietly discard forcing moves rather than fail loudly.
+    void CompareGivesCheckAgainstMakeMove(ChessBoard& board, int depth)
+    {
+        for (const auto move : board.GetLegalMoves())
+        {
+            const bool predicted = board.GivesCheck(move);
+            board.MakeMove(move);
+            const bool actual = board.IsInCheck();
+            Require(predicted == actual, "GivesCheck disagreed with the move generator");
+            if (depth > 1)
+                CompareGivesCheckAgainstMakeMove(board, depth - 1);
+            board.UndoMove(move);
+        }
+    }
+
+    void TestGivesCheck()
+    {
+        static constexpr std::string_view positions[] = {
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+            "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+            // En passant, promotion and castling are the three cases where the board
+            // after the move differs from "piece moves from A to B".
+            "8/8/1k6/2b5/2pP4/8/5K2/8 b - d3 0 1",
+            "4k3/1P6/8/8/8/8/6p1/4K3 w - - 0 1",
+            "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+            "8/8/8/8/1k6/8/2P5/4K2R w K - 0 1",
+        };
+
+        for (const auto fen : positions)
+        {
+            ChessBoard board{ std::string(fen) };
+            CompareGivesCheckAgainstMakeMove(board, 3);
+        }
+    }
+
     void TestNullMoveState()
     {
         ChessBoard board("4k3/8/8/3pP3/8/8/8/4K3 w - d6 17 42");
@@ -634,15 +674,73 @@ namespace
         SearchLimits limits;
         limits.maxDepth = 6;
 
-        ChessBoard strategic("r1bq1rk1/pp2bppp/2n1pn2/2pp4/3P4/2PBPN2/PP1N1PPP/R1BQ1RK1 w - - 4 9");
-        Require(search.Search(strategic, limits).bestMove == FindMove(strategic, "d4c5"),
-            "search missed the benchmark's strongest strategic break");
+        // Forced mates behind a quiet sacrifice. These are the positions a selective
+        // search gets wrong first: the key move is quiet, orders badly, and is exactly
+        // what late-move and futility pruning discard. Asserting on the mate score as
+        // well as the move keeps the test about the search rather than about taste.
+        struct MateCase
+        {
+            std::string_view fen;
+            std::string_view move;
+            int mateInPlies;
+        };
+        static constexpr MateCase mates[] = {
+            { "2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - 0 1", "g3g6", 3 },
+            { "1k1r4/pp1b1R2/3q2pp/4p3/2B5/4Q3/PPP2B2/2K5 b - - 0 1", "d6d1", 5 },
+            { "r5rk/5p1p/5R2/4B3/8/8/7P/7K w - - 0 1", "f6a6", 5 },
+        };
+
+        for (const MateCase& mate : mates)
+        {
+            search.NewGame();
+            ChessBoard board{ std::string(mate.fen) };
+            SearchLimits mateLimits;
+            mateLimits.maxDepth = mate.mateInPlies + 3;
+            const SearchResult result = search.Search(board, mateLimits);
+            Require(result.bestMove == FindMove(board, mate.move),
+                "search missed a forced mate behind a quiet move");
+            Require(result.score >= SCORE_MATE - MAX_PLY,
+                "search found the mating move without a mate score");
+        }
 
         search.NewGame();
         ChessBoard tactical("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
         const auto bestMove = search.Search(tactical, limits).bestMove;
         Require(bestMove == FindMove(tactical, "d5e6") || bestMove == FindMove(tactical, "e2a6"),
             "search missed both top tactical continuations in the benchmark");
+    }
+
+    // The magic tables are generated from the ray-walking functions, so the constant-time
+    // lookups must agree with them for every occupancy. Move ordering and evaluation both
+    // read the tables directly, so a mismatch would be silent.
+    void TestSliderAttackLookups()
+    {
+        using NeraChessEngine::Bitboard;
+        using NeraChessEngine::MoveGenerator;
+
+        uint64_t state = 0x9E3779B97F4A7C15ULL;
+        const auto nextRandom = [&state]()
+        {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            return state;
+        };
+
+        for (uint8_t square = 0; square < 64; ++square)
+        {
+            for (int trial = 0; trial < 64; ++trial)
+            {
+                // Sparse occupancies resemble real positions more than uniform bits do.
+                const Bitboard occupancy = nextRandom() & nextRandom() & nextRandom();
+                Require(MoveGenerator::LookupRookAttacks(square, occupancy) ==
+                        MoveGenerator::CalculatePossibleRookMoves(square, occupancy),
+                    "magic rook lookup disagrees with the ray walk");
+                Require(MoveGenerator::LookupBishopAttacks(square, occupancy) ==
+                        MoveGenerator::CalculatePossibleBishopMoves(square, occupancy),
+                    "magic bishop lookup disagrees with the ray walk");
+            }
+        }
     }
 
     void TestStaticExchangeEvaluation()
@@ -855,6 +953,7 @@ int main(int argc, char** argv)
         TestTerminalPositions();
         TestRepetition();
         TestIncrementalZobrist();
+        TestGivesCheck();
         TestNullMoveState();
         TestTranspositionTable();
         TestConcurrentTranspositionTable();
@@ -863,6 +962,7 @@ int main(int argc, char** argv)
         TestMultithreadedSearch();
         TestTaperedEvaluation();
         TestSearchChoices();
+        TestSliderAttackLookups();
         TestStaticExchangeEvaluation();
         TestClockAndTimeManagement();
         TestOpeningBook();

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ The public [NeraChess Lichess bot](https://lichess.org/@/NeraChess) provides a s
 - Aspiration windows and mate-distance pruning
 - Alpha-Beta Pruning
 - Clustered transposition table with configurable size
-- Late Move Reductions (LMR)
-- Null-move, futility, delta, and static-exchange pruning
+- Logarithmic Late Move Reductions, scaled by history score, cut-node state, and
+  whether the position is improving
+- Null-move, reverse futility, futility, late-move-count, delta, and
+  static-exchange pruning
+- Internal iterative reduction on nodes with no stored move
+- Static-evaluation stack driving an "improving" signal for every margin
 - Quiescence Search
 - Killer Moves
 - Side-aware history, killer, and countermove heuristics

--- a/docs/ENGINE_STRENGTH.md
+++ b/docs/ENGINE_STRENGTH.md
@@ -1,5 +1,12 @@
 # Engine strength calibration
 
+## Scope note
+
+The calibrated rating below is from engine commit `212e012` and has **not** been
+re-measured since. The selective-search rewrite is documented separately in
+[Change validation](#change-validation) with self-play and cross-check numbers,
+which are not a rating and do not replace the calibration.
+
 ## Result
 
 At engine code commit `212e012`, NeraChess measured **2627 Stockfish 18
@@ -125,6 +132,40 @@ The generated PGN SHA-256 values were:
   `4ca0897d3992cf28bcc3bb607737f4b2deb2c3f30057c887bbe90e80de9b47cc`
 - Focused tournament:
   `294ba6659a0a2584f530844d1e477df94039881ef679499bb9149a49a2d18e75`
+
+## Change validation
+
+Individual engine changes are validated with paired-opening matches rather than by
+re-running the calibration above. This section records the selective-search rewrite.
+None of these numbers is a rating.
+
+Conditions: Apple M3, 8 logical CPUs, Release build, one thread, 16 MiB hash per engine,
+opening book disabled, `3 s + 0.03 s`. Openings are seeded four-ply random walks from the
+start position, rejected when the pre-change engine evaluates them beyond ±150 cp, and
+each is played twice with colors reversed. Intervals are bootstrapped over opening pairs
+rather than over individual games.
+
+Head to head against the previous search:
+
+| Games | W-D-L | Score | Elo | 95% interval |
+| ---: | ---: | ---: | ---: | --- |
+| 600 | 327-148-125 | 66.8% | +121.7 | +97.4 to +146.5 |
+
+Self-play differences overstate what a change is worth against an unrelated opponent, so
+both builds also played the same foreign anchor over the same openings — Stockfish 18
+with `UCI_LimitStrength=true` and `UCI_Elo=2400`:
+
+| Build | W-D-L | Score vs anchor | Elo vs anchor |
+| --- | ---: | ---: | ---: |
+| Before | 373-63-164 | 67.4% | +126.3 |
+| After | 425-47-128 | 74.8% | +188.5 |
+
+The gap against the fixed anchor is about **+62 Elo**, roughly half the self-play figure,
+which is the usual relationship. The score difference is 7.4 percentage points with a
+standard error near 2.6, so the direction is resolved at this sample size.
+
+Search depth summed over eight fixed positions at three seconds each rose from 127 to
+141 plies.
 
 ## How to read this result
 

--- a/docs/ENGINE_STRENGTH.md
+++ b/docs/ENGINE_STRENGTH.md
@@ -145,7 +145,10 @@ start position, rejected when the pre-change engine evaluates them beyond ±150 
 each is played twice with colors reversed. Intervals are bootstrapped over opening pairs
 rather than over individual games.
 
-Head to head against the previous search:
+Head to head against the previous search, meaning the search at commit `322a50a`.
+This branch also supersedes the log-based late move reductions merged separately in
+#4, which are not in either build below and have not been measured against this
+pruning layer.
 
 | Games | W-D-L | Score | Elo | 95% interval |
 | ---: | ---: | ---: | ---: | --- |

--- a/docs/IMPROVEMENT_BACKLOG.md
+++ b/docs/IMPROVEMENT_BACKLOG.md
@@ -1,0 +1,186 @@
+# NeraChess — engine strength improvement backlog
+
+Analysis of `main` @ `322a50a` (2026-08-10). Baseline measured on Apple M3, 8 logical
+CPUs, Release build, 1 thread, 64 MiB hash, book disabled.
+
+## Baseline measurements
+
+`--search-bench` (fixed depth 6): 1.34M–3.00M nps.
+
+Fixed 3 s per position via UCI (`scripts` probe, 8 positions):
+
+| Position | depth | nodes | nps |
+| --- | ---: | ---: | ---: |
+| startpos | 15 | 5.28M | 2.03M |
+| kiwipete | 12 | 2.41M | 1.32M |
+| endgame (8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8) | 25 | 7.57M | 3.67M |
+| pos4 | 17 | 4.61M | 1.77M |
+| pos5 | 15 | 1.97M | 1.30M |
+| sicilian | 15 | 3.55M | 1.51M |
+| closed | 15 | 4.79M | 1.63M |
+| kingatk | 13 | 2.35M | 1.45M |
+| **total** | **127** | 32.5M | |
+
+**The headline problem:** ~1.5–2.0M nps is a respectable node rate, but reaching only
+depth 13–15 in a middlegame at 3 s is 4–6 plies shallower than engines with the same
+node rate. The tree is not selective enough — nodes are being spent on moves that
+should have been reduced or pruned. This is a search-shape problem, not a speed problem.
+
+---
+
+## Ranked improvements
+
+### 1. Search selectivity overhaul — *biggest single lever*
+
+`NeraChessSearch/src/SearchEngine.cpp` `PrincipalVariationSearch()`.
+
+Everything in the selective layer is either capped at trivial depths or absent:
+
+- **Reverse futility / static null move** is limited to `depth <= 2`
+  (`SearchEngine.cpp:409`, margin `120 * depth`). Standard range is depth ≤ 6–8.
+- **Futility pruning** is limited to `depth <= 2` (`SearchEngine.cpp:410`) and is
+  evaluated *after* `MakeMove`, so the expensive part is paid before the decision.
+- **Late move pruning / move-count pruning is entirely absent.** Nothing skips quiet
+  moves purely because they are late at low depth.
+- **SEE pruning in the main search is absent.** SEE is only used in qsearch
+  (`SearchEngine.cpp:634`) and in move ordering. Losing captures and losing quiets are
+  searched at full width.
+- **History pruning is absent** — history scores never influence whether a move is
+  skipped.
+- **LMR is very weak** (`SearchEngine.cpp:860-870`): `1 + (depth>=6) + (moveIndex>=8) - pvNode`,
+  so maximum reduction is ~3 plies and only 1–2 in most nodes. Modern log-based tables
+  reach 4–7 plies for late quiets at high depth. It also ignores history score,
+  improving, and cutnode.
+- **No "improving" heuristic and no static-eval stack.** Every margin is depth-only;
+  there is no notion of whether the position is getting better for the side to move.
+- **No Internal Iterative Reduction** for nodes with no TT move.
+- **No razoring, no ProbCut, no multi-cut.**
+
+Expected: the largest available gain. Depth 15 → 19–20 at the same time budget.
+
+### 2. Extensions — *completely missing*
+
+`grep` for `depth + 1` across `NeraChessSearch/src` returns only an unrelated SEE loop.
+The search never extends. Missing, in rough order of value:
+
+- **Check extensions** (extend when the move gives check, gated by SEE or depth).
+- **Singular extensions** (needs an `excludedMove` parameter threaded through
+  `PrincipalVariationSearch` and a TT-key adjustment).
+- Recapture / passed-pawn-push extensions.
+
+Without extensions, forced tactical lines terminate at the same depth as quiet ones,
+which is also why LMR cannot safely be made aggressive today.
+
+### 3. Continuation history (follow-up / counter-move history)
+
+`SearchEngine.h:128-129` has only a butterfly table `m_History[side][from][to]` and a
+1-slot `m_CounterMoves[piece][to]`. There is no piece-to keyed continuation history at
+1 and 2 plies back, and no capture history. Continuation history is one of the highest
+value-per-line heuristics in modern engines: it improves ordering everywhere and gives
+LMR/pruning a much better signal than a butterfly table.
+
+### 4. Two-fold repetition detection inside the search
+
+`ChessBoard::GetGameOver()` (`ChessBoard.cpp:648`) declares a draw only at
+`GetRepetitionCount(...) >= 3`. Inside a search tree the standard is to score the
+*first* repetition of a position as a draw. As written, NeraChess must find a genuine
+three-fold before it sees a perpetual, so it can walk into perpetual check, miss a
+saving perpetual, and waste nodes re-searching repeated positions. Needs a search-side
+"repetition since root or twofold in history" test rather than a change to game rules.
+
+### 5. Move-generation and per-node allocation overhead (speed)
+
+- `ChessBoard::GetLegalMoves()` (`ChessBoard.cpp:605`) returns `MoveList<218>` **by
+  value** — an ~880-byte copy at every node that calls it.
+- `MoveList` value-initializes its 218-entry array (`MoveList.h:72`), so every
+  construction memsets ~872 bytes.
+- `SearchEngine::SortMoves()` zero-initializes `std::array<int32_t, 218> scores{}`
+  (`SearchEngine.cpp:678`) at every node — another ~872-byte memset.
+- `PrincipalVariationSearch` zero-initializes `std::array<Move, 218> quietMovesSearched{}`
+  (`SearchEngine.cpp:449`) per node.
+- `ChessBoard::MakeMove` pushes to `std::vector<Move> m_MovesPlayed` and
+  `RepetitionTable`'s `std::vector<uint64_t>` per node (heap-backed).
+- Quiescence generates **all** legal moves and then filters to captures
+  (`SearchEngine.cpp:616-620`); there is no captures-only generation mode.
+- Move ordering fully sorts every move list; staged/lazy selection would avoid scoring
+  moves after a cutoff.
+
+Together these are plausibly worth 1.5–2× nps.
+
+### 6. Evaluation quality
+
+`NeraChessSearch/src/Evaluation.cpp` is PeSTO piece-square tables plus a thin set of
+hand-tuned terms. Missing or crude:
+
+- King safety is a flat `-6 per attacked king-ring square` (`Evaluation.cpp:385`);
+  no attacker-count/attack-weight table, no safe-check detection, no king zone beyond
+  the 8 adjacent squares.
+- No threat terms (hanging pieces, pawn pushes attacking pieces, minor-behind-pawn).
+- No knight/bishop outposts, no rook-on-7th, no trapped-bishop/rook detection.
+- Pawn structure has isolated/doubled/passed/supported only — no backward pawns, no
+  connected-pawn ramp, no passed-pawn blocker/king-distance/rook-behind terms.
+- No pawn hash table; `IsPassedPawn()` (`Evaluation.cpp:191`) is a nested loop per pawn
+  per evaluation.
+- No endgame scaling (opposite-coloured bishops, single-minor draws, wrong-rook-pawn),
+  no 50-move-counter score damping.
+- No specialized mate-with-KRK/KBNK drive-to-corner knowledge.
+
+### 7. Evaluation tuning
+
+`README.md` already lists this as a known limitation. Texel/Adam tuning of the PSQTs
+and term weights against a labelled position set is normally worth a lot, but it needs
+a self-generated dataset (this repo has no game database), so it is a project rather
+than a patch.
+
+### 8. NNUE evaluation
+
+The single largest theoretical jump (several hundred Elo) but out of scope for one
+change: it needs data generation, a trainer, an incremental accumulator in `ChessBoard`,
+and a net file with a compatible license.
+
+### 9. Time management
+
+`NeraChessSearch/src/TimeManagement.cpp` divides remaining time by a fixed
+move estimate. Missing:
+
+- Best-move stability scaling (spend less when the root move has not changed for
+  several iterations, more when it just changed).
+- Score-drop / fail-low extension of the soft limit.
+- Node-fraction-based effort redistribution across root moves.
+- The soft-time check only happens *between* iterations (`SearchEngine.cpp:271`), so a
+  long final iteration always overshoots to the hard limit.
+
+### 10. Transposition table
+
+- `TTEntry` (`TranspositionTable.h:21`) stores no static eval, so nothing can be
+  cached for the pruning layer.
+- Depth is `int8_t` and qsearch stores at depth 0, which mixes qsearch and depth-0
+  main-search entries.
+- No TT prefetch after choosing a move.
+- Aspiration re-searches call `SearchRoot` from scratch rather than keeping root move
+  ordering from the previous iteration.
+
+### 11. Root/aspiration handling
+
+- The window starts at ±25 and doubles symmetrically (`SearchEngine.cpp:229-248`);
+  widening only on the failing side is standard and cheaper.
+- Root moves are re-sorted from the TT each iteration rather than being kept in
+  previous-iteration score order.
+- No root move-count-based reduction and no per-root-move node accounting.
+
+### 12. Syzygy endgame tablebases
+
+Absent. Worth real Elo in long time controls and would repair endgame technique, but it
+is an external dependency and a large amount of probing code.
+
+---
+
+## Chosen for implementation
+
+**Item 1 — search selectivity overhaul**, on branch `search-selectivity`.
+
+Rationale: the measured symptom (depth 13–15 at 3 s with 1.5–2 M nps) points directly
+at it, it is entirely internal to `SearchEngine.cpp`, it needs no new data, no external
+dependency, and no rules changes, and each sub-part is independently measurable with
+self-play. Items 2 and 3 are its natural follow-ups — in particular check extensions
+are what make aggressive reductions safe, so a minimal check extension is included.

--- a/docs/IMPROVEMENT_BACKLOG.md
+++ b/docs/IMPROVEMENT_BACKLOG.md
@@ -182,5 +182,35 @@ is an external dependency and a large amount of probing code.
 Rationale: the measured symptom (depth 13–15 at 3 s with 1.5–2 M nps) points directly
 at it, it is entirely internal to `SearchEngine.cpp`, it needs no new data, no external
 dependency, and no rules changes, and each sub-part is independently measurable with
-self-play. Items 2 and 3 are its natural follow-ups — in particular check extensions
-are what make aggressive reductions safe, so a minimal check extension is included.
+self-play.
+
+### What shipped
+
+Depth-scaled reverse futility and futility pruning, late-move-count pruning, a
+logarithmic LMR table adjusted by history/improving/cut-node/killer state, internal
+iterative reduction, and a static-evaluation stack behind an `improving` signal.
+Pruning decisions moved ahead of `MakeMove`, which needed a new
+`ChessBoard::GivesCheck` so that checking moves could stay exempt.
+
+Item 5 was partly addressed along the way: static exchange evaluation was walking rays
+instead of using the magic tables it was built from. Switching it leaves every search
+result identical and raises the node rate 6–9%.
+
+Depth summed over the eight probe positions went from **127 to 141**.
+
+### Measured, and rejected
+
+Both were tried on top of the shipped layer and removed. They are recorded here so they
+are not re-attempted blindly — each may still be worth revisiting under the conditions
+noted.
+
+| Change | Result (600 games, 3 s + 0.03 s) | Why |
+| --- | --- | --- |
+| Blanket check extensions, capped at `ply < 2 * rootDepth` | −11.6 Elo, 95% CI [−34.9, +12.2] | Cost ~1.4 plies of depth. The pruning exemption for checking moves already captures most of the benefit. A tighter gate (safe checks only, or PV nodes only) is untested. |
+| SEE pruning of losing quiet moves, depth ≤ 7 | −22.6 Elo, 95% CI [−43.7, −1.7] | `StaticExchangeEvaluation` copies twelve bitboards per call and was measured before the magic-table fix. Worth retrying now that SEE is cheaper, and cheaper still if the sort's SEE results were reused instead of recomputed. |
+
+### Natural follow-ups
+
+Items 2 (extensions, with a tighter gate than the one rejected above), 3 (continuation
+history), and 4 (search-side two-fold repetition) are the next candidates, in that
+order. Item 5's remaining per-node copies are now the largest speed item left.


### PR DESCRIPTION
Rebases the selective-search work onto current `main` (which now carries the log-based
LMR from #4) and replaces the shallow pruning layer with a depth-scaled selective search.

## What is in here

- **Selective search** (`SearchEngine.cpp`): a static-evaluation stack behind an
  `improving` signal, reverse futility to depth 7, futility to depth 6, late-move-count
  pruning, a logarithmic LMR table adjusted by history / PV / cut-node / improving /
  killer state, and internal iterative reduction on nodes with no stored move. Pruning
  decisions moved ahead of `MakeMove`, so a discarded move costs a predicate instead of
  a move generation.
- **`ChessBoard::GivesCheck`**: answers "does this move check?" without making it, which
  is what makes the checking-move exemption from every prune affordable. Without that
  exemption the search took until depth 12 to see a mate it had previously found at
  depth 3.
- **Constant-time slider lookups**: static exchange evaluation was ray-walking instead of
  using the magic tables it was built from. Switching leaves every search result
  identical and raises the node rate 6-9%.
- **Docs**: a ranked improvement backlog with the baseline it was derived from, and the
  validation record for this change.

## Relationship to #4

This supersedes the log-based late move reductions merged in #4. They are two designs for
one mechanism rather than two features, so the rebase could not keep both. The reduction
curve, its adjustments, and the move index reductions start from are part of the same
selectivity design as the pruning layer here, so they are replaced together rather than
layered. The `MAX_HISTORY` constant introduced by #4 is kept.

The two were never measured head to head, and `docs/ENGINE_STRENGTH.md` now says so
explicitly rather than leaving a reader to assume either way.

## Measurements

All against the search at `322a50a`, on an Apple M3, Release, one thread, 16 MiB hash,
book off, `3 s + 0.03 s`, intervals bootstrapped over opening pairs:

| Games | W-D-L | Score | Elo | 95% interval |
| ---: | ---: | ---: | ---: | --- |
| 600 | 327-148-125 | 66.8% | +121.7 | +97.4 to +146.5 |

Against a fixed foreign anchor (Stockfish 18, `UCI_Elo=2400`) over the same openings, the
two builds differ by about **+62 Elo**, which is what the change is actually worth. Depth
summed over eight fixed positions at three seconds each rose from 127 to 141.

Two variants were tried and dropped as negative over 600 games each: blanket check
extensions (-11.6 Elo) and static-exchange pruning of losing quiet moves (-22.6 Elo).
Both are recorded in the backlog with the conditions under which they may be worth
revisiting.

## Tests

`NeraChessTests` passes. `GivesCheck` is compared against `MakeMove` plus `IsInCheck`
over every move of every position in a three-ply tree from positions covering en passant,
promotion and castling; the slider lookups are compared against the ray walk over sparse
random occupancies from all 64 squares. The regression suite's strategic-move assertion,
which required one specific quiet move at exactly depth 6, is replaced by three forced
mates behind quiet sacrifices that assert the mate score as well as the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
