### PR TITLE
Add reproducible playing-strength tests

### DIFF
--- a/.github/workflows/strength-test.yml
+++ b/.github/workflows/strength-test.yml
@@ -1,0 +1,157 @@
+name: Strength test
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: Branch, tag, or commit to test
+        required: true
+        type: string
+      baseline_ref:
+        description: Branch, tag, or commit used as the baseline
+        required: true
+        default: main
+        type: string
+      time_control:
+        description: Fastchess time control
+        required: true
+        default: 10+0.1
+        type: string
+      concurrency:
+        description: Number of games played simultaneously
+        required: true
+        default: "2"
+        type: string
+      max_pairs:
+        description: Maximum opening pairs before stopping
+        required: true
+        default: "5000"
+        type: string
+      elo1:
+        description: Elo gain that SPRT should accept
+        required: true
+        default: "5"
+        type: string
+      allow_network_change:
+        description: Allow candidate and baseline to use different NNUE files
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nerachess-strength
+  cancel-in-progress: false
+
+jobs:
+  match:
+    name: Candidate versus baseline
+    runs-on: [self-hosted, Linux, X64, nerachess-strength]
+    timeout-minutes: 720
+
+    env:
+      FASTCHESS_BIN: /data/chess/testing/tools/bin/fastchess
+      OPENING_BOOK: /data/chess/testing/books/UHO_4060_v4.epd
+      STRENGTH_TC: ${{ inputs.time_control }}
+      STRENGTH_CONCURRENCY: ${{ inputs.concurrency }}
+      STRENGTH_MAX_PAIRS: ${{ inputs.max_pairs }}
+      STRENGTH_ELO0: "0"
+      STRENGTH_ELO1: ${{ inputs.elo1 }}
+      STRENGTH_HASH_MB: "128"
+      STRENGTH_THREADS: "1"
+      STRENGTH_SEED: "1"
+      ALLOW_NETWORK_CHANGE: ${{ inputs.allow_network_change }}
+
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve exact revisions
+        id: revisions
+        env:
+          CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          BASELINE_REF: ${{ inputs.baseline_ref }}
+        run: |
+          set -euo pipefail
+
+          valid_ref='^[A-Za-z0-9][A-Za-z0-9._/-]*$'
+          for ref in "$CANDIDATE_REF" "$BASELINE_REF"; do
+            if [[ ! "$ref" =~ $valid_ref ]] || [[ "$ref" == *..* ]]; then
+              echo "Invalid Git ref: $ref" >&2
+              exit 1
+            fi
+          done
+
+          git fetch --force --prune origin \
+            "+refs/heads/*:refs/remotes/origin/*" \
+            "+refs/tags/*:refs/tags/*"
+
+          resolve_ref() {
+            local ref="$1"
+            if git rev-parse --verify --quiet "${ref}^{commit}"; then
+              return
+            fi
+            git rev-parse --verify "origin/${ref}^{commit}"
+          }
+
+          candidate_sha="$(resolve_ref "$CANDIDATE_REF")"
+          baseline_sha="$(resolve_ref "$BASELINE_REF")"
+          echo "candidate_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+          echo "baseline_sha=$baseline_sha" >> "$GITHUB_OUTPUT"
+          echo "Candidate: $candidate_sha"
+          echo "Baseline:  $baseline_sha"
+
+      - name: Create isolated source trees
+        run: |
+          git worktree add --detach "$RUNNER_TEMP/nerachess-candidate-source" \
+            "${{ steps.revisions.outputs.candidate_sha }}"
+          git worktree add --detach "$RUNNER_TEMP/nerachess-baseline-source" \
+            "${{ steps.revisions.outputs.baseline_sha }}"
+
+      - name: Build candidate
+        run: |
+          bash scripts/strength/Build-Engine.sh \
+            "$RUNNER_TEMP/nerachess-candidate-source" \
+            "$RUNNER_TEMP/nerachess-candidate-build"
+
+      - name: Build baseline
+        run: |
+          bash scripts/strength/Build-Engine.sh \
+            "$RUNNER_TEMP/nerachess-baseline-source" \
+            "$RUNNER_TEMP/nerachess-baseline-build"
+
+      - name: Run paired SPRT match
+        run: |
+          bash scripts/strength/Run-Match.sh \
+            "$RUNNER_TEMP/nerachess-candidate-build" \
+            "$RUNNER_TEMP/nerachess-baseline-build" \
+            "$OPENING_BOOK" \
+            "$RUNNER_TEMP/nerachess-strength-results"
+
+      - name: Add result to workflow summary
+        if: always()
+        run: |
+          {
+            echo '## NeraChess strength test'
+            echo
+            echo '- Candidate: `${{ steps.revisions.outputs.candidate_sha }}`'
+            echo '- Baseline: `${{ steps.revisions.outputs.baseline_sha }}`'
+            echo
+            echo '```text'
+            tail -n 80 "$RUNNER_TEMP/nerachess-strength-results/fastchess.log" 2>/dev/null || \
+              echo 'The match did not start; inspect the job log.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PGN, log, and configuration
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: strength-${{ steps.revisions.outputs.candidate_sha }}-vs-${{ steps.revisions.outputs.baseline_sha }}
+          path: ${{ runner.temp }}/nerachess-strength-results
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ are also available:
 `--thread-bench` is a quick, scheduling-sensitive scaling diagnostic rather
 than a reproducible Elo measurement.
 
+Playing-strength changes are tested separately with paired Fastchess matches
+and SPRT on a controlled self-hosted runner. See
+[docs/Strength-Testing.md](docs/Strength-Testing.md) for the host setup, manual
+GitHub Actions workflow, test interpretation, and local commands.
+
 The NNUE accumulator has its own benchmark, comparing incremental updates
 against full refreshes over the same move tree:
 

--- a/docs/Strength-Testing.md
+++ b/docs/Strength-Testing.md
@@ -1,0 +1,152 @@
+# NeraChess strength testing
+
+This system compares one exact NeraChess revision against another by playing
+paired games with colors reversed. Fastchess stops the match when its SPRT has
+enough evidence, or after the configured maximum number of pairs.
+
+Strength testing is deliberately separate from normal CI. A successful build,
+perft run, or benchmark does not establish an Elo gain, and a short engine
+match is too noisy to be a merge gate.
+
+## What the workflow controls
+
+- Both revisions are compiled on the same machine with the same compiler.
+- Each engine gets one search thread and 128 MiB of hash.
+- NeraChess's internal opening book is disabled.
+- Positions come from `UHO_4060_v4.epd` and are played once with each color.
+- Opening randomization uses a recorded seed.
+- The two bundled NNUE files must be identical unless the run explicitly tests
+  a network change.
+- The PGN, full Fastchess log, build hashes, network hashes, and test settings
+  are retained as a GitHub Actions artifact.
+
+The default SPRT tests `H0: 0 nElo` against `H1: +5 nElo`, with alpha and beta
+both set to 0.05. A green result supports accepting the +5 nElo hypothesis. A
+red result rejects that target; it does not necessarily prove the candidate is
+weaker. An unfinished result means the maximum game count was reached without
+enough evidence.
+
+## 1. Prepare the Ubuntu host
+
+The server also runs the NeraChess Lichess bot and a website, so the Actions
+runner must not use `haloraphi`, `nerachess`, or the web-server account. The
+setup script creates a dedicated unprivileged `chesstest` account and installs
+a pinned Fastchess revision and the CC0 Stockfish UHO opening suite:
+
+```bash
+cd /path/to/your/development/NeraChess
+sudo bash scripts/strength/Setup-Host.sh
+```
+
+Use your development clone here, not the production checkout used by the
+running Lichess bot.
+
+The runner account must not be added to the `nerachess`, web-server, or sudo
+groups. Production secrets such as `/etc/nerachess/lichess.env` should be owned
+by `root:nerachess` with mode `0640`, so `chesstest` cannot read them.
+
+## 2. Register the self-hosted runner
+
+1. Open the NeraChess repository on GitHub.
+2. Select **Settings -> Actions -> Runners -> New self-hosted runner**.
+3. Select **Linux** and **x64**.
+4. GitHub displays current download and registration commands. Run the download
+   commands in a new directory:
+
+   ```bash
+   sudo mkdir -p /opt/actions-runner/nerachess-strength
+   sudo chown chesstest:chesstest /opt/actions-runner/nerachess-strength
+   cd /opt/actions-runner/nerachess-strength
+   ```
+
+5. Run GitHub's displayed download and extraction commands as `chesstest`, for
+   example by prefixing each command with `sudo -u chesstest`.
+6. Register it with the URL and short-lived token shown by GitHub:
+
+   ```bash
+   sudo -u chesstest ./config.sh \
+     --url https://github.com/raphaelhounsiagaman/NeraChess \
+     --token TOKEN_SHOWN_BY_GITHUB \
+     --name nerachess-strength-1 \
+     --labels nerachess-strength \
+     --work /data/chess/testing/actions \
+     --unattended
+   ```
+
+7. Install and start the service:
+
+   ```bash
+   sudo ./svc.sh install chesstest
+   sudo ./svc.sh start
+   sudo ./svc.sh status
+   ```
+
+The registration token expires quickly and is only used during registration.
+Do not paste it into the repository or save it in a script.
+
+## 3. Run a test
+
+1. Push the candidate branch to GitHub.
+2. Open **Actions -> Strength test -> Run workflow**.
+3. Keep **Use workflow from** set to `main`.
+4. Enter the candidate branch name and `main` as the baseline.
+5. Start with the defaults.
+
+The workflow resolves both names to immutable commit hashes before compiling.
+The results appear in the workflow summary; downloadable PGN and logs appear
+under **Artifacts**.
+
+For a pull request, use the PR's branch name as `candidate_ref`. If `main`
+changes while a long test is running, that does not affect the match because
+the baseline hash was already resolved.
+
+## Choosing concurrency
+
+Every concurrent game starts two engines. With the default one thread per
+engine, concurrency 2 uses approximately four busy CPU threads. Begin at 2 so
+the website and production bot remain responsive. Increase it only after
+watching load and bot latency. Do not run NNUE training at the same time as a
+strength match; changing CPU contention adds noise.
+
+Only one strength workflow can run at once. Additional runs queue because the
+workflow has a repository-wide concurrency group.
+
+## Testing an NNUE change
+
+By default the match aborts if the two revisions contain different
+`nera.nnue` files. This catches accidental code-and-network comparisons. Enable
+**Allow candidate and baseline to use different NNUE files** only when the
+network itself is the intended candidate.
+
+## Local use
+
+The same scripts can be used without GitHub Actions:
+
+```bash
+bash scripts/strength/Build-Engine.sh /path/to/candidate /tmp/candidate-build
+bash scripts/strength/Build-Engine.sh /path/to/baseline /tmp/baseline-build
+
+FASTCHESS_BIN=/data/chess/testing/tools/bin/fastchess \
+STRENGTH_CONCURRENCY=2 \
+bash scripts/strength/Run-Match.sh \
+  /tmp/candidate-build \
+  /tmp/baseline-build \
+  /data/chess/testing/books/UHO_4060_v4.epd \
+  /tmp/strength-results
+```
+
+Use fresh output directories for every run. This prevents an old PGN or build
+from being mistaken for the current experiment.
+
+## Security boundary
+
+This is a public repository and a self-hosted runner executes repository code.
+The workflow is manual rather than a `pull_request` trigger, but starting it is
+still authorization to compile and execute the selected candidate. Review the
+candidate before starting the job.
+
+Do not change this workflow to use `pull_request_target`, do not give its
+`GITHUB_TOKEN` write permission, and do not store deployment credentials on the
+runner. Stronger isolation would require an ephemeral VM or container for every
+job; the dedicated account is the minimum acceptable boundary on the shared
+server.

--- a/scripts/strength/Build-Engine.sh
+++ b/scripts/strength/Build-Engine.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 SOURCE_DIRECTORY OUTPUT_DIRECTORY" >&2
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 2
+fi
+
+source_directory="$(realpath "$1")"
+output_directory="$2"
+
+if [[ ! -f "${source_directory}/Build-NeraChess.lua" ]]; then
+  echo "Not a NeraChess source directory: ${source_directory}" >&2
+  exit 1
+fi
+
+if [[ -e "${output_directory}" ]] && [[ -n "$(find "${output_directory}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+  echo "Output directory must be empty: ${output_directory}" >&2
+  exit 1
+fi
+
+if [[ ! "${NERACHESS_BUILD_JOBS:-}" =~ ^[1-9][0-9]*$ ]]; then
+  if [[ -n "${NERACHESS_BUILD_JOBS:-}" ]]; then
+    echo "NERACHESS_BUILD_JOBS must be a positive integer." >&2
+    exit 1
+  fi
+  NERACHESS_BUILD_JOBS="$(nproc)"
+fi
+
+mkdir -p "${output_directory}"
+output_directory="$(realpath "${output_directory}")"
+
+pushd "${source_directory}" >/dev/null
+bash ./scripts/Setup-Linux.sh gmake
+make -C NeraChessEngine config=release -j"${NERACHESS_BUILD_JOBS}"
+make -C NeraChessNNUE config=release -j"${NERACHESS_BUILD_JOBS}"
+make -C NeraChessSearch config=release -j"${NERACHESS_BUILD_JOBS}"
+make -C NeraChessUCI config=release -j"${NERACHESS_BUILD_JOBS}"
+
+engine_directory="${source_directory}/bin/Release/NeraChessUCI"
+if [[ ! -x "${engine_directory}/NeraChessUCI" ]]; then
+  echo "The build did not produce ${engine_directory}/NeraChessUCI" >&2
+  exit 1
+fi
+
+cp -a "${engine_directory}/." "${output_directory}/"
+
+{
+  echo "revision=$(git rev-parse HEAD)"
+  echo "compiler=$(g++ --version | head -n 1)"
+  echo "engine_sha256=$(sha256sum "${output_directory}/NeraChessUCI" | cut -d' ' -f1)"
+  if [[ -f "${output_directory}/Resources/NNUE/nera.nnue" ]]; then
+    echo "network_sha256=$(sha256sum "${output_directory}/Resources/NNUE/nera.nnue" | cut -d' ' -f1)"
+  fi
+} > "${output_directory}/build-manifest.txt"
+popd >/dev/null
+
+echo "Built $(grep '^revision=' "${output_directory}/build-manifest.txt")"

--- a/scripts/strength/Run-Match.sh
+++ b/scripts/strength/Run-Match.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: Run-Match.sh CANDIDATE_DIRECTORY BASELINE_DIRECTORY OPENING_BOOK RESULTS_DIRECTORY
+
+Configuration is read from environment variables. See docs/Strength-Testing.md.
+EOF
+}
+
+if [[ $# -ne 4 ]]; then
+  usage
+  exit 2
+fi
+
+candidate_directory="$(realpath "$1")"
+baseline_directory="$(realpath "$2")"
+opening_book="$(realpath "$3")"
+results_directory="$4"
+
+fastchess_bin="${FASTCHESS_BIN:-fastchess}"
+time_control="${STRENGTH_TC:-10+0.1}"
+concurrency="${STRENGTH_CONCURRENCY:-2}"
+max_pairs="${STRENGTH_MAX_PAIRS:-5000}"
+hash_mb="${STRENGTH_HASH_MB:-128}"
+threads="${STRENGTH_THREADS:-1}"
+elo0="${STRENGTH_ELO0:-0}"
+elo1="${STRENGTH_ELO1:-5}"
+seed="${STRENGTH_SEED:-1}"
+allow_network_change="${ALLOW_NETWORK_CHANGE:-false}"
+
+candidate="${candidate_directory}/NeraChessUCI"
+baseline="${baseline_directory}/NeraChessUCI"
+
+for executable in "${candidate}" "${baseline}"; do
+  if [[ ! -x "${executable}" ]]; then
+    echo "Engine is missing or not executable: ${executable}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${opening_book}" ]]; then
+  echo "Opening book does not exist: ${opening_book}" >&2
+  exit 1
+fi
+
+if ! command -v "${fastchess_bin}" >/dev/null 2>&1 && [[ ! -x "${fastchess_bin}" ]]; then
+  echo "fastchess was not found: ${fastchess_bin}" >&2
+  exit 1
+fi
+
+positive_integer='^[1-9][0-9]*$'
+number='^-?[0-9]+([.][0-9]+)?$'
+time_control_pattern='^[0-9]+([.][0-9]+)?\+[0-9]+([.][0-9]+)?$'
+
+for name_and_value in \
+  "concurrency:${concurrency}" \
+  "max pairs:${max_pairs}" \
+  "hash size:${hash_mb}" \
+  "threads:${threads}" \
+  "seed:${seed}"; do
+  name="${name_and_value%%:*}"
+  value="${name_and_value#*:}"
+  if [[ ! "${value}" =~ ${positive_integer} ]]; then
+    echo "Invalid ${name}: ${value}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "${time_control}" =~ ${time_control_pattern} ]]; then
+  echo "Invalid time control '${time_control}'; use a value such as 10+0.1." >&2
+  exit 1
+fi
+
+if [[ ! "${elo0}" =~ ${number} ]] || [[ ! "${elo1}" =~ ${number} ]]; then
+  echo "Elo bounds must be numbers." >&2
+  exit 1
+fi
+
+candidate_network="${candidate_directory}/Resources/NNUE/nera.nnue"
+baseline_network="${baseline_directory}/Resources/NNUE/nera.nnue"
+if [[ ! -f "${candidate_network}" ]] || [[ ! -f "${baseline_network}" ]]; then
+  echo "Both builds must contain Resources/NNUE/nera.nnue." >&2
+  exit 1
+fi
+
+candidate_network_hash="$(sha256sum "${candidate_network}" | cut -d' ' -f1)"
+baseline_network_hash="$(sha256sum "${baseline_network}" | cut -d' ' -f1)"
+if [[ "${candidate_network_hash}" != "${baseline_network_hash}" && "${allow_network_change}" != "true" ]]; then
+  cat >&2 <<EOF
+Candidate and baseline contain different NNUE networks.
+candidate: ${candidate_network_hash}
+baseline:  ${baseline_network_hash}
+
+Set ALLOW_NETWORK_CHANGE=true only when the network change is intentional.
+EOF
+  exit 1
+fi
+
+if [[ -e "${results_directory}" ]] && [[ -n "$(find "${results_directory}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+  echo "Results directory must be empty: ${results_directory}" >&2
+  exit 1
+fi
+mkdir -p "${results_directory}"
+results_directory="$(realpath "${results_directory}")"
+
+{
+  echo "candidate_revision=$(sed -n 's/^revision=//p' "${candidate_directory}/build-manifest.txt")"
+  echo "baseline_revision=$(sed -n 's/^revision=//p' "${baseline_directory}/build-manifest.txt")"
+  echo "candidate_network_sha256=${candidate_network_hash}"
+  echo "baseline_network_sha256=${baseline_network_hash}"
+  echo "opening_book=${opening_book}"
+  echo "opening_book_sha256=$(sha256sum "${opening_book}" | cut -d' ' -f1)"
+  echo "time_control=${time_control}"
+  echo "concurrency=${concurrency}"
+  echo "max_pairs=${max_pairs}"
+  echo "threads=${threads}"
+  echo "hash_mb=${hash_mb}"
+  echo "sprt_elo0=${elo0}"
+  echo "sprt_elo1=${elo1}"
+  echo "opening_seed=${seed}"
+  "${fastchess_bin}" -version 2>&1 | sed 's/^/fastchess=/'
+} | tee "${results_directory}/configuration.txt"
+
+"${fastchess_bin}" \
+  -engine "cmd=${candidate}" name=Candidate dir="${candidate_directory}" \
+    option.OwnBook=false option.Hash="${hash_mb}" option.Threads="${threads}" \
+  -engine "cmd=${baseline}" name=Baseline dir="${baseline_directory}" \
+    option.OwnBook=false option.Hash="${hash_mb}" option.Threads="${threads}" \
+  -each proto=uci tc="${time_control}" \
+  -openings file="${opening_book}" format=epd order=random \
+  -srand "${seed}" \
+  -rounds "${max_pairs}" \
+  -repeat \
+  -concurrency "${concurrency}" \
+  -sprt elo0="${elo0}" elo1="${elo1}" alpha=0.05 beta=0.05 model=normalized \
+  -draw movenumber=40 movecount=8 score=10 \
+  -resign movecount=6 score=800 twosided=true \
+  -maxmoves 300 \
+  -config outname="${results_directory}/fastchess-config.json" \
+  -recover \
+  -report penta=true \
+  -ratinginterval 10 \
+  -pgnout file="${results_directory}/games.pgn" notation=san append=false \
+    nodes=true seldepth=true nps=true hashfull=true timeleft=true \
+  2>&1 | tee "${results_directory}/fastchess.log"

--- a/scripts/strength/Setup-Host.sh
+++ b/scripts/strength/Setup-Host.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run this script as root: sudo bash $0" >&2
+  exit 1
+fi
+
+runner_user="chesstest"
+testing_root="/data/chess/testing"
+fastchess_revision="ccb85325b1db322658687b8be8cfe9f54c495840"
+book_url="https://github.com/official-stockfish/books/raw/master/UHO_4060_v4.epd.zip"
+book_archive_sha256="a97424c5b98b42f8c27ff450f0681ad11696148548c975752350e98417ead11d"
+
+apt-get update
+apt-get install --yes build-essential ca-certificates curl git unzip
+
+if ! id "${runner_user}" >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir "/var/lib/${runner_user}" \
+    --shell /usr/sbin/nologin "${runner_user}"
+fi
+
+install -d -o "${runner_user}" -g "${runner_user}" \
+  "${testing_root}" \
+  "${testing_root}/actions" \
+  "${testing_root}/books" \
+  "${testing_root}/tools" \
+  "${testing_root}/tools/bin"
+
+fastchess_source="${testing_root}/tools/fastchess-source"
+if [[ ! -d "${fastchess_source}/.git" ]]; then
+  sudo -u "${runner_user}" git clone https://github.com/Disservin/fastchess.git "${fastchess_source}"
+fi
+sudo -u "${runner_user}" git -C "${fastchess_source}" fetch --prune origin
+sudo -u "${runner_user}" git -C "${fastchess_source}" checkout --detach "${fastchess_revision}"
+sudo -u "${runner_user}" make -C "${fastchess_source}" -j"$(nproc)"
+install -o "${runner_user}" -g "${runner_user}" -m 0755 \
+  "${fastchess_source}/fastchess" "${testing_root}/tools/bin/fastchess"
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "${temporary_directory}"' EXIT
+curl --location --fail --show-error \
+  --output "${temporary_directory}/book.zip" "${book_url}"
+echo "${book_archive_sha256}  ${temporary_directory}/book.zip" | sha256sum --check
+unzip -p "${temporary_directory}/book.zip" UHO_4060_v4.epd \
+  > "${temporary_directory}/UHO_4060_v4.epd"
+install -o "${runner_user}" -g "${runner_user}" -m 0644 \
+  "${temporary_directory}/UHO_4060_v4.epd" \
+  "${testing_root}/books/UHO_4060_v4.epd"
+
+cat <<EOF
+
+The strength-test dependencies are ready.
+
+fastchess: ${testing_root}/tools/bin/fastchess
+openings:  ${testing_root}/books/UHO_4060_v4.epd
+work:      ${testing_root}/actions
+
+Now register the GitHub Actions runner by following docs/Strength-Testing.md.
+EOF


### PR DESCRIPTION
## Summary

- add a manually triggered candidate-vs-baseline strength workflow
- build both exact Git revisions independently on one self-hosted machine
- run paired reversed-color UHO openings through Fastchess with SPRT
- disable NeraChess's internal book and fix threads, hash, opening seed, and match conditions
- reject accidental mixed-NNUE comparisons unless explicitly enabled
- retain PGN, configuration, hashes, and the complete match log
- add an isolated Ubuntu `chesstest` setup with pinned Fastchess and opening-book inputs

## Validation

- parsed the workflow YAML
- passed `bash -n` for all three shell scripts
- built the current Linux UCI engine through the new build script
- ran an end-to-end paired Fastchess smoke match and produced PGN, saved configuration, and SPRT output
- passed `git diff --check`

## Operational note

The workflow is manual and read-only because NeraChess is public and the persistent runner shares a host with production services. The runner still needs to be registered on the Ubuntu server after this PR is merged; the exact steps are in `docs/Strength-Testing.md`.