### PR TITLE
Dispatch the NNUE output layer to AVX2/SSE4.1 at runtime on x86

### DIFF
--- a/NeraChessNNUE/src/NnueEvaluator.cpp
+++ b/NeraChessNNUE/src/NnueEvaluator.cpp
@@ -113,7 +113,7 @@ namespace NeraChessNNUE::Evaluator
         }
 
         return "network " + MutablePath().filename().string() + ' ' +
-            network.GetHeader().Describe() + ", kernels " + Simd::TargetName;
+            network.GetHeader().Describe() + ", kernels " + Simd::TargetName();
     }
 
     Score Evaluate(const BoardState& state, Accumulator& accumulator)

--- a/NeraChessNNUE/src/SimdOps.h
+++ b/NeraChessNNUE/src/SimdOps.h
@@ -17,10 +17,17 @@
 // trained network happens to produce -- and TestNnueSimdKernels checks the
 // vector and scalar paths against each other on adversarial inputs.
 //
-// Selection is at compile time. The defaults are the widest instruction set
-// each platform guarantees: NEON on AArch64, SSE2 on x86-64. AVX2 is used when
-// the build enables it (-mavx2, /arch:AVX2), which is worth doing for a machine
-// you control but cannot be the default without dropping pre-2013 CPUs.
+// Selection is mostly at compile time. The defaults are the widest instruction
+// set each platform guarantees: NEON on AArch64, SSE2 on x86-64. AVX2 is used
+// throughout when the build enables it (-mavx2, /arch:AVX2), which is worth
+// doing for a machine you control but cannot be the default without dropping
+// pre-2013 CPUs. The one exception is ActivatedDotProduct on an SSE2-baseline
+// GCC/Clang x86 build: it has no SSE2 vector implementation (see below), so it
+// instead picks an AVX2 or SSE4.1 clone of the scalar loop at runtime via
+// function multiversioning. That choice is resolved once per process and
+// every clone is bit-exact with Simd::Scalar by construction, so two Lazy SMP
+// workers in the same process -- the only place a disagreement could poison
+// the shared transposition table -- always agree.
 
 // AArch64 rather than any NEON: the kernels use vmull_high_s16 and
 // vmovl_high_s32, which 32-bit ARM's NEON does not provide.
@@ -79,17 +86,96 @@ namespace NeraChessNNUE::Simd
     // -- Dispatch ----------------------------------------------------------
 
 #if defined(NNUE_SIMD_NEON)
-    inline constexpr const char* TargetName = "neon";
     inline constexpr size_t Lanes = 8;
+    inline const char* TargetName() { return "neon"; }
 #elif defined(NNUE_SIMD_AVX2)
-    inline constexpr const char* TargetName = "avx2";
     inline constexpr size_t Lanes = 16;
+    inline const char* TargetName() { return "avx2"; }
 #elif defined(NNUE_SIMD_SSE2)
-    inline constexpr const char* TargetName = "sse2";
     inline constexpr size_t Lanes = 8;
+
+    // SSE2 has no vector implementation of ActivatedDotProduct below (SSE2
+    // lacks a 32-bit packed multiply, and emulating one costs more than it
+    // saves: 248 ns vs 259 ns for a 512-wide call, measured). GCC/Clang
+    // function multiversioning lets the binary carry AVX2 and SSE4.1 clones
+    // of the scalar loop and pick between them at runtime with
+    // __builtin_cpu_supports, without forcing the whole translation unit --
+    // and therefore every pre-2013 x86-64 target -- onto a newer baseline.
+    // Accumulator kernels (Add/Subtract/AddSubtract) already have an SSE2
+    // vector path and are unaffected.
+#if defined(__GNUC__) || defined(__clang__)
+    #define NNUE_SIMD_X86_DISPATCH 1
+#endif
+
+#if defined(NNUE_SIMD_X86_DISPATCH)
+    namespace Dispatch
+    {
+        // Each tier below is bit-exact with Scalar::ActivatedDotProduct by
+        // construction: it is the identical loop, recompiled at a wider
+        // target so the vectorizer reassociates the additions. That is safe
+        // because no reassociation can overflow -- a squared clip times an
+        // int16 weight fits in int32, and the running int64 total cannot
+        // overflow for any int16 weight the format permits (at most 512
+        // terms, each under 65025 * 32767 < 2^31) -- so every grouping of the
+        // sum produces the same int64 value.
+        __attribute__((target("avx2")))
+        inline Accumulation DotAvx2(const Weight* values, const Weight* weights, size_t count)
+        {
+            Accumulation sum = 0;
+            for (size_t index = 0; index < count; ++index)
+                sum += Quantization::Activate(values[index]) * weights[index];
+            return sum;
+        }
+
+        __attribute__((target("sse4.1")))
+        inline Accumulation DotSse41(const Weight* values, const Weight* weights, size_t count)
+        {
+            Accumulation sum = 0;
+            for (size_t index = 0; index < count; ++index)
+                sum += Quantization::Activate(values[index]) * weights[index];
+            return sum;
+        }
+
+        enum class Tier { Avx2, Sse41, Baseline };
+
+        inline Tier DetectTier()
+        {
+            __builtin_cpu_init();
+            // __builtin_cpu_supports checks OS-enabled YMM/XMM state (via
+            // XGETBV), not just the CPUID feature bit, so it cannot select a
+            // tier the OS has not enabled register state for.
+            if (__builtin_cpu_supports("avx2"))
+                return Tier::Avx2;
+            if (__builtin_cpu_supports("sse4.1"))
+                return Tier::Sse41;
+            return Tier::Baseline;
+        }
+
+        // Resolved once; the microarchitecture a process runs on cannot
+        // change while it runs.
+        inline Tier SelectedTier()
+        {
+            static const Tier tier = DetectTier();
+            return tier;
+        }
+    }
+#endif
+
+    inline const char* TargetName()
+    {
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        switch (Dispatch::SelectedTier())
+        {
+        case Dispatch::Tier::Avx2:      return "sse2 (dispatch: avx2)";
+        case Dispatch::Tier::Sse41:     return "sse2 (dispatch: sse4.1)";
+        case Dispatch::Tier::Baseline:  break;
+        }
+#endif
+        return "sse2";
+    }
 #else
-    inline constexpr const char* TargetName = "scalar";
     inline constexpr size_t Lanes = 1;
+    inline const char* TargetName() { return "scalar"; }
 #endif
 
     // Architecture::HiddenSize is asserted to be a multiple of 16, so every
@@ -316,9 +402,20 @@ namespace NeraChessNNUE::Simd
         const Accumulation sum = lanes[0] + lanes[1] + lanes[2] + lanes[3];
         return sum + Scalar::ActivatedDotProduct(values + index, weights + index, count - index);
 #else
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        switch (Dispatch::SelectedTier())
+        {
+        case Dispatch::Tier::Avx2:
+            return Dispatch::DotAvx2(values, weights, count);
+        case Dispatch::Tier::Sse41:
+            return Dispatch::DotSse41(values, weights, count);
+        case Dispatch::Tier::Baseline:
+            break;
+        }
+#endif
         // SSE2 lacks a 32-bit packed multiply (that is SSE4.1), and emulating
-        // one costs more than it saves. Builds that want a vector output layer
-        // on x86 should enable AVX2.
+        // one costs more than it saves, so hardware the dispatch tiers above
+        // reject (or a non-GCC/Clang toolchain) falls back to scalar.
         return Scalar::ActivatedDotProduct(values, weights, count);
 #endif
     }

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -808,6 +808,38 @@ namespace
             "a file shorter than its header was accepted");
     }
 
+    // ActivatedDotProduct's AVX2/SSE4.1 clones on an SSE2-baseline x86 build
+    // (NeraChessNNUE/src/SimdOps.h) are runtime-multiversioned rather than
+    // compile-time selected, so exercising Simd::ActivatedDotProduct alone
+    // only tests whichever tier this machine happens to pick. Call every
+    // tier the binary carries directly -- guarded by the same CPU-support
+    // check the dispatcher itself uses, since calling an AVX2 clone on
+    // hardware without AVX2 is a SIGILL, not a wrong answer.
+    void RequireDispatchTiersAgree(const Nnue::Weight* values, const Nnue::Weight* weights,
+        size_t length)
+    {
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        const Nnue::Accumulation reference =
+            Nnue::Simd::Scalar::ActivatedDotProduct(values, weights, length);
+        if (__builtin_cpu_supports("sse4.1"))
+        {
+            Require(Nnue::Simd::Dispatch::DotSse41(values, weights, length) == reference,
+                "SIMD ActivatedDotProduct's SSE4.1 dispatch tier disagrees with the scalar "
+                "reference at length " + std::to_string(length));
+        }
+        if (__builtin_cpu_supports("avx2"))
+        {
+            Require(Nnue::Simd::Dispatch::DotAvx2(values, weights, length) == reference,
+                "SIMD ActivatedDotProduct's AVX2 dispatch tier disagrees with the scalar "
+                "reference at length " + std::to_string(length));
+        }
+#else
+        (void)values;
+        (void)weights;
+        (void)length;
+#endif
+    }
+
     void TestNnueSimdKernels()
     {
         // Vector kernels must agree with the scalar reference exactly, not
@@ -880,6 +912,8 @@ namespace
                     Nnue::Simd::Scalar::ActivatedDotProduct(values.data(), added.data(), length),
                     "SIMD ActivatedDotProduct disagrees with the scalar reference at length " +
                         std::to_string(length));
+
+                RequireDispatchTiersAgree(values.data(), added.data(), length);
             }
         }
 
@@ -892,6 +926,7 @@ namespace
             Nnue::Simd::Scalar::ActivatedDotProduct(saturated.data(), extremeWeights.data(),
                 saturated.size()),
             "SIMD ActivatedDotProduct overflows where the scalar reference does not");
+        RequireDispatchTiersAgree(saturated.data(), extremeWeights.data(), saturated.size());
     }
 
     void TestNnueFeatureIndexing()
@@ -1351,7 +1386,7 @@ namespace
         const Nnue::Network& network = Nnue::Evaluator::GetNetwork();
 
         std::cout << "NNUE evaluation benchmark (" << network.GetHeader().Describe() << ")\n"
-                  << "kernels " << Nnue::Simd::TargetName << "\n\n";
+                  << "kernels " << Nnue::Simd::TargetName() << "\n\n";
 
         for (const BenchCase& testCase : cases)
         {

--- a/README.md
+++ b/README.md
@@ -365,8 +365,9 @@ parameters, A/B testing a new network, and installing the result — and
   strength quoted above, which was measured with the hand-crafted evaluation it
   replaced. Training a stronger one is a matter of running more generations at
   greater depth.
-- x86 builds use a vectorized accumulator but a scalar output layer unless AVX2
-  is enabled at compile time.
+- x86 builds without AVX2 enabled at compile time get vector accumulator
+  updates. The output layer's dot product is runtime-dispatched to an AVX2 or
+  SSE4.1 kernel on GCC/Clang; MSVC still falls back to scalar there.
 - Search performance and calibrated strength depend on hardware, thread count, and time control.
 
 ---

--- a/docs/NNUE.md
+++ b/docs/NNUE.md
@@ -295,9 +295,18 @@ on x86-64. AVX2 is used when the build enables it:
 make config=release CXXFLAGS="-mavx2"
 ```
 
-x86 builds without AVX2 get vector accumulator updates but a scalar output
-layer. SSE2 has no packed 32-bit multiply — that arrived with SSE4.1 — and
-emulating one costs more than it saves.
+x86 builds without AVX2 get vector accumulator updates. The output layer's
+activated dot product has no SSE2 vector kernel — SSE2 has no packed 32-bit
+multiply, that arrived with SSE4.1, and emulating one costs more than it
+saves — but on GCC/Clang it does not fall back to scalar either: function
+multiversioning gives the binary AVX2 and SSE4.1 clones of the scalar loop
+(`Simd::Dispatch` in `SimdOps.h`), and `ActivatedDotProduct` picks between
+them at runtime with `__builtin_cpu_supports`, resolved once per process.
+Every clone is bit-exact with `Simd::Scalar` by construction — it is the same
+loop, recompiled at a wider target, and the accumulation argument below holds
+regardless of how the additions are reassociated. MSVC has no `target`
+attribute, so it keeps the plain scalar fallback. `Simd::TargetName()` reports
+the tier actually selected, not just the one compiled.
 
 ### Exactness is the constraint, not speed
 


### PR DESCRIPTION
## Summary

The default x86-64 release build targets the SSE2 baseline. `Simd::ActivatedDotProduct` (the output layer, called twice per `Network::Forward`) has no SSE2 vector kernel — SSE2 lacks the 32-bit packed multiply the squared-clipped-ReLU dot product needs, and emulating one costs more than it saves — so every default release build ran the output layer through the scalar loop even though the accumulator kernels (`Add`/`Subtract`/`AddSubtract`) were already vectorized.

This adds GCC/Clang function multiversioning so `ActivatedDotProduct` carries AVX2 and SSE4.1 clones of the scalar loop and picks between them at runtime with `__builtin_cpu_supports`, without moving the whole translation unit off the SSE2 baseline (and therefore without dropping pre-2013 x86-64 CPUs from the supported target). The search tree is unchanged — this is pure throughput.

Closes #13.

## Problem

`NeraChessNNUE/src/SimdOps.h`'s SSE2 branch fell straight through to `Scalar::ActivatedDotProduct`, and nothing in the build ever asked for AVX2 (not `Build-NeraChessNNUE.lua`, not `scripts/strength/Build-Engine.sh`, not the self-play/strength-test harness), so every self-play result and every strength-test run to date was produced by the scalar output layer. `README.md` and `docs/NNUE.md` both recorded this as a known limitation without a fix.

## Implementation

- `Simd::Dispatch::DotAvx2` / `DotSse41` (`NeraChessNNUE/src/SimdOps.h`) are `__attribute__((target("avx2")))` / `target("sse4.1")` clones of the identical scalar loop, resolved once per process via `Dispatch::SelectedTier()` (a function-local `static`, `__builtin_cpu_supports`-based). `ActivatedDotProduct`'s SSE2 branch dispatches to whichever tier the CPU supports, falling back to `Scalar::ActivatedDotProduct` on hardware with neither (or a non-GCC/Clang toolchain, e.g. MSVC, which has no `target` attribute and keeps today's scalar path).
- `Simd::TargetName` changed from a compile-time constant to a function so the `info string` banner and `--nnue-bench` output report the tier actually selected (e.g. `sse2 (dispatch: avx2)`), not just the one compiled.
- `TestNnueSimdKernels` (`NeraChessTests/src/main.cpp`) now calls each compiled tier directly — guarded by the same CPU-support check the dispatcher uses, since invoking an AVX2 clone on hardware without AVX2 is a SIGILL — instead of only exercising whichever tier the test machine happens to pick, on the existing adversarial inputs (int16 extremes, values either side of the activation's clipping ceiling, a saturated accumulator against the largest weights the format allows).
- `README.md` and `docs/NNUE.md` updated to describe the new dispatch behavior instead of the old "scalar output layer" limitation.

## Why this approach

Each dispatch tier is bit-exact with `Simd::Scalar` **by construction**, not by review: it is the identical loop, recompiled at a wider target so the vectorizer reassociates the `int64` additions. That reassociation cannot change the result because no grouping can overflow — a squared clip times an int16 weight fits in int32, and the running int64 total is bounded well under 2^40 for the largest weights the format permits (at most 512 terms, each under 65025 × 32767 < 2^31). This also keeps two Lazy SMP workers in the same process in agreement (the tier is resolved once per process), which is the property that actually matters for the shared transposition table — cross-machine determinism was never a real constraint here.

A hand-written AVX2 intrinsics kernel was considered and rejected: the issue's own measurements showed the compiler auto-vectorizing the plain scalar loop at `-mavx2`/`-msse4.1` beats hand-written intrinsics at both tiers, so reusing the scalar loop is both simpler and faster than writing new intrinsics.

## Validation

```
Debug build (NeraChessEngine, NeraChessNNUE, NeraChessSearch, NeraChessUCI, NeraChessTests): PASS, no warnings
Release build (same targets): PASS, no warnings
NeraChessTests (debug + release, --eval-file NeraChessApp/Resources/NNUE/nera.nnue): PASS
  including TestNnueSimdKernels' new per-tier checks (SSE4.1 and AVX2 clones vs. Simd::Scalar)
--bench (perft): 119,060,324 nodes, PASS
scripts/Test-UciPonder.py against the release UCI binary: PASS
NNUETraining test suite (python3 -m unittest discover): 69 passed, 4 skipped (no torch in this environment)
```

Info string banner confirms the tier actually selected: `kernels sse2 (dispatch: avx2)`.

**Tree unchanged, confirmed directly.** Fixed `go depth 12` through the UCI engine over 6 positions (startpos, kiwipete, and 4 more), baseline vs. candidate: node counts identical in every position (1,338,491 nodes total, both builds) and every best move identical. NPS up 5-15% per position on this shared/virtualized runner (noisier than dedicated hardware).

**Throughput, `--nnue-bench` incremental eval/s** (3 runs each, this machine):
```
              baseline (sse2)      candidate (dispatch: avx2)
start:        ~1.11-1.13M          ~1.86-1.88M   (+65-70%)
kiwipete:     ~1.06-1.11M          ~1.74-1.82M   (+60-65%)
endgame:      ~1.08-1.10M          ~1.77-1.86M   (+65-70%)
```

## Strength test

1,000-game screening match, 10+0.1, paired openings, via the repository's `strength-test` GitHub Actions workflow.

```
Games: 1000
Time control: 10+0.1
Candidate: 3039313cbaba6078bb25ad43d8b1953a9acf81c7
Baseline:  9e5d158296aeaea2178bac19160674030bdfa6de (main)
W/D/L: 338 / 397 / 265
Candidate score: 53.65%
Estimated Elo: +25.4
Approximate paired 95% interval: [+10.4, +40.5]
Verdict: Likely improvement
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/32619865206
```

The interval excludes zero on the positive side, consistent with this being a fixed-time-control node-rate gain converting into extra search depth rather than a change in what is searched. As the workflow's own summary notes, this is a screening result, not proof of the exact Elo figure.

## Risks

- The gain is measured on shared/virtualized CI and sandbox hardware; the *relative* speedup should transfer to other AVX2-capable x86-64 hardware, but the exact percentage will vary.
- This covers only the output layer. The three accumulator kernels (`Add`/`Subtract`/`AddSubtract`) already have SSE2 vector paths, so they see no change here — a further AVX2 dispatch for those is a separate, smaller follow-up the original issue calls out but which this PR does not attempt, to keep the change scoped to the output layer.
- MSVC builds are unaffected (no `target` attribute support) and keep today's scalar output-layer path; this PR does not attempt Windows/MSVC dispatch, matching the scoping the issue itself recommended.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AtboakRhrL83MdCUtUGU3K)_