### PR TITLE
Scale time-management ceilings with the clock instead of pinning to 10s/15s

### DIFF
--- a/NeraChessSearch/src/TimeManagement.cpp
+++ b/NeraChessSearch/src/TimeManagement.cpp
@@ -33,7 +33,10 @@ namespace NeraChessSearch::TimeManagement
         // Never plan to spend more than a quarter of the remaining clock on a
         // single move, however few moves the estimator thinks are left. This
         // scales with the time control, unlike a fixed millisecond ceiling.
-        softTime = std::min({ softTime, available, remaining / 4 });
+        // Floored at 1 ms: integer division can round remaining / 4 to 0 when
+        // remaining is a few milliseconds, and SearchEngine treats a zero
+        // soft limit as disabled rather than as "stop immediately".
+        softTime = std::min({ softTime, available, std::max(milliseconds{ 1 }, remaining / 4) });
 
         milliseconds hardTime = std::max(softTime, softTime * 3 / 2 + milliseconds{ 50 });
         hardTime = std::min(hardTime, available);

--- a/NeraChessSearch/src/TimeManagement.cpp
+++ b/NeraChessSearch/src/TimeManagement.cpp
@@ -30,10 +30,13 @@ namespace NeraChessSearch::TimeManagement
             : (fullMove < 20 ? 30 : (fullMove < 40 ? 24 : 18));
         milliseconds softTime = remaining / estimatedMovesLeft + increment * 3 / 4;
         softTime = std::max(milliseconds{ 20 }, softTime);
-        softTime = std::min({ softTime, available, milliseconds{ 10'000 } });
+        // Never plan to spend more than a quarter of the remaining clock on a
+        // single move, however few moves the estimator thinks are left. This
+        // scales with the time control, unlike a fixed millisecond ceiling.
+        softTime = std::min({ softTime, available, remaining / 4 });
 
         milliseconds hardTime = std::max(softTime, softTime * 3 / 2 + milliseconds{ 50 });
-        hardTime = std::min({ hardTime, available, milliseconds{ 15'000 } });
+        hardTime = std::min(hardTime, available);
         softTime = std::min(softTime, hardTime);
 
         SearchLimits limits;

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -1547,8 +1547,20 @@ namespace
         const auto defaultLimits = CalculateLimits(board, defaultClock);
         Require(defaultLimits.softTime == seconds{ 10 },
             "default time manager soft limit is incorrect");
-        Require(defaultLimits.hardTime == seconds{ 15 },
+        Require(defaultLimits.hardTime > seconds{ 15 } && defaultLimits.hardTime < minutes{ 1 },
             "default time manager hard limit is incorrect");
+
+        // The budget must scale with the clock instead of pinning to a fixed
+        // ceiling once the per-move share crosses it (issue: time management
+        // caps every search at 10s soft / 15s hard regardless of time control).
+        Clock longClock(minutes{ 90 }, seconds{ 40 });
+        const auto longLimits = CalculateLimits(board, longClock);
+        Require(longLimits.softTime > defaultLimits.softTime * 5,
+            "time manager budget did not scale up for a much longer clock");
+        Require(longLimits.hardTime > defaultLimits.hardTime * 5,
+            "time manager hard limit did not scale up for a much longer clock");
+        Require(longLimits.hardTime < minutes{ 90 },
+            "time manager hard limit ignored the clock safety reserve");
 
         Clock lowClock(milliseconds{ 1'000 }, milliseconds{ 100 });
         const auto lowLimits = CalculateLimits(board, lowClock);


### PR DESCRIPTION
## Summary

`TimeManagement::CalculateLimits` clamped the soft/hard search-time budget to fixed constants (10 s / 15 s) regardless of the actual time control. Once the per-move share the formula computes crossed those constants — which happens once roughly 3–5 minutes are on the clock — every extra second of remaining time was silently discarded. Replaces the fixed ceiling with one that scales with the remaining clock, so the engine actually uses the time control it's given instead of pinning to a blitz-scale budget at all longer controls.

Closes #12.

## Problem

`CalculateLimits` (`NeraChessSearch/src/TimeManagement.cpp`) computed a per-move share as `remaining / estimatedMovesLeft + increment * 3 / 4`, then clamped it with `std::min({ softTime, available, milliseconds{ 10'000 } })` for the soft limit and an equivalent `15'000` ms clamp for the hard limit. Below ~5 minutes remaining those constants never bind and the formula behaves as intended; above that, they override it completely, so the engine used the *same* ~15 s hard limit whether it had 15 minutes, 90 minutes, or an hour left on the clock. `NeraChessBot` and `UciSession` both route through this function, so the cap applied to tournament play and the desktop app equally.

Verified directly against the built UCI engine before the fix (identical to the numbers described in the issue):

| `go` command | budget used |
| --- | ---: |
| `wtime 10000 winc 100` (10+0.1) | ~0.6 s |
| `wtime 900000 winc 10000` (15+10) | 15.00 s |
| `wtime 5400000 winc 40000` (90+40) | 15.00 s |
| `wtime 3600000 winc 40000` (60 min left) | 15.00 s |

`TestClockAndTimeManagement` asserted the two fixed constants directly for the default 5+0 clock, which is exactly at the boundary where the cap first binds — so the test looked like it was pinning intended behavior when it was really only pinning the bug.

## Implementation

`softTime` is now capped at `min(softTime, available, remaining / 4)` instead of a fixed 10 s, and `hardTime` keeps only the existing `available` (clock-minus-safety-reserve) clamp, dropping the fixed 15 s ceiling. `movesToGo` handling, the safety reserve, and the derivation of `hardTime` from `softTime` are unchanged — this only removes the two absolute constants and replaces one of them with a clock-relative fraction, so the cap still scales down for very short time controls where the old constants never bound in the first place.

`TestClockAndTimeManagement` now asserts that the budget for a 90+40 clock is materially larger than for the 5+0 default (rather than pinning both to the old fixed constants), which is the property that was actually missing.

## Why this approach

A fixed millisecond ceiling doesn't scale with the time control at all; a fraction of the remaining clock does, while still acting as a safety rail against the per-move formula ever claiming an unreasonable share of the clock (relevant mainly for very few estimated moves left combined with a large increment). `hardTime` didn't need its own new fraction-based ceiling: it's already bounded by `available` (remaining minus the existing safety reserve), which is the actual flag-safety constraint, so removing its fixed 15 s clamp doesn't introduce any new flagging risk.

I considered also adding a UI-side ceiling in `NeraChessBot`/`NeraChessApp` (so a human at the desktop board isn't left waiting minutes per move), which the issue raises as a design option. I left it out: it's a separate UX concern from the correctness bug this PR fixes, the app's own time-control presets (including 90 min + 40 sec) already represent a deliberate user choice, and adding a new artificial cap there would be scope creep beyond issue #12 itself.

## Validation

```
Release build (NeraChessEngine, NeraChessNNUE, NeraChessSearch, NeraChessUCI, NeraChessTests): PASS, no warnings
Debug build (same targets): PASS, no warnings
NeraChessTests (debug + release, --eval-file NeraChessApp/Resources/NNUE/nera.nnue): PASS
  including the updated TestClockAndTimeManagement scaling assertions
scripts/Test-UciPonder.py against the release UCI binary: PASS
```

Direct behavioral check against the built UCI engine, same `go` commands as above, after the fix:

| `go` command | budget used (before → after) |
| --- | --- |
| `wtime 10000 winc 100` (10+0.1) | 0.6 s → 0.7 s (unaffected, as expected — cap never bound here) |
| `wtime 900000 winc 10000` (15+10) | 15.00 s → 56.3 s |
| `wtime 5400000 winc 40000` (90+40) | 15.00 s → 210–275 s |
| `wtime 3600000 winc 40000` (60 min left) | 15.00 s → 203–206 s |

No game/search ever approached its remaining clock in these probes (all well under `wtime`), so there's no flagging risk from the wider budget.

## Strength test

1,000-game screening match, 10+0.1, paired openings, via the repository's `strength-test` GitHub Actions workflow.

```
Games: 1000
Time control: 10+0.1
Candidate: 48f4d6eec9267327282d246db834ea97e824e6c3
Baseline:  440de876c9b1fafda2883b439e3f9376242ec530 (main, includes #14)
W/D/L: 299 / 414 / 287
Candidate score: 50.60%
Estimated Elo: +4.2
Approximate paired 95% interval: [-10.4, +18.8]
Verdict: No clear difference
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/32642199241
```

This result is expected and doesn't test this change's actual effect: at 10+0.1 the old and new code compute byte-identical time budgets (the per-move share never gets anywhere near the old 10 s/15 s constants, so the fixed clamp was never live at this time control either), so a neutral result here is exactly the "nothing else broke" confirmation, not evidence about the fix itself.

I looked into running the screening match at a time control long enough for the fix to actually bind (roughly 5+ minutes base time, per the table above). That's infeasible within the existing workflow's fixed 1,000-game count and 350-minute-per-shard timeout: the "15+10" row alone measures ~56 s per move against this exact build, and even the cheapest time control where the two code paths diverge at all implies per-move times far above the workflow's effective budget once multiplied across 250 games/shard at concurrency 2 (the 10+0.1 match phase itself took ~69 minutes end-to-end, and per-move cost scales roughly linearly with the base time needed to clear the old ceiling). So the case for this change rests on the direct UCI measurements above and the correctness/regression validation, not on an SPRT — same reasoning the issue itself lays out for why `docs/ENGINE_STRENGTH.md`'s existing benchmark never caught this.

## Risks

- No new flagging risk: `hardTime` is still bounded by `available` (remaining minus the existing safety reserve), which is unchanged.
- Long time controls now let the engine think substantially longer per move (e.g. ~210 s at 90+40 vs. 15 s before). This is the intended fix, but it's a large behavioral change for those controls specifically, and it hasn't been validated by self-play at those controls for the reason described above.
- The `remaining / 4` fraction is a new, somewhat arbitrary safety rail (the issue suggested this shape without prescribing the exact fraction). It doesn't bind in any of the measured scenarios above; it only matters for edge cases like very few estimated moves left combined with a large increment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3j7eKRug8oNn28xbo6tdB)_