### PR TITLE
Fuse the accumulator copy into the delta pass, dispatch feature-transformer kernels to AVX2

### DIFF
--- a/NeraChessNNUE/src/Accumulator.cpp
+++ b/NeraChessNNUE/src/Accumulator.cpp
@@ -4,6 +4,7 @@
 #include "SimdOps.h"
 
 #include <algorithm>
+#include <cassert>
 
 namespace NeraChessNNUE
 {
@@ -73,6 +74,59 @@ namespace NeraChessNNUE
         }
     }
 
+    void Accumulator::ApplyDeltaFrom(const Network& network, const Weight* source,
+        const FeatureSet::FeatureDelta& delta, Perspective perspective)
+    {
+        if (!network.IsLoaded())
+            return;
+
+        Weight* target = (*this)[perspective];
+        // Push's out-of-room guard (m_Top >= MaxAccumulatorPly) is what keeps
+        // this from ever aliasing: it is the one case where two plies would
+        // otherwise clamp onto the same entry.
+        assert(target != source &&
+            "ApplyDeltaFrom's source must not alias the accumulator it writes");
+
+        const size_t paired = std::min(delta.addedCount, delta.removedCount);
+
+        // The first delta operation reads `source` (the parent) and writes
+        // `target` (this, the child) directly, folding in the copy that a
+        // plain ApplyDelta would need done ahead of time. Every operation
+        // after the first is in place on `target`, exactly as in ApplyDelta.
+        if (paired > 0)
+        {
+            Simd::CopyAddSubtract(target, source, network.FeatureColumn(delta.added[0]),
+                network.FeatureColumn(delta.removed[0]), Architecture::HiddenSize);
+        }
+        else if (delta.addedCount > 0)
+        {
+            Simd::CopyAdd(target, source, network.FeatureColumn(delta.added[0]),
+                Architecture::HiddenSize);
+        }
+        else if (delta.removedCount > 0)
+        {
+            Simd::CopySubtract(target, source, network.FeatureColumn(delta.removed[0]),
+                Architecture::HiddenSize);
+        }
+        else
+        {
+            Simd::Copy(target, source, Architecture::HiddenSize);
+        }
+
+        for (size_t index = 1; index < paired; ++index)
+        {
+            Simd::AddSubtract(target, network.FeatureColumn(delta.added[index]),
+                network.FeatureColumn(delta.removed[index]), Architecture::HiddenSize);
+        }
+        for (size_t index = std::max<size_t>(paired, 1); index < delta.addedCount; ++index)
+            Simd::Add(target, network.FeatureColumn(delta.added[index]), Architecture::HiddenSize);
+        for (size_t index = std::max<size_t>(paired, 1); index < delta.removedCount; ++index)
+        {
+            Simd::Subtract(target, network.FeatureColumn(delta.removed[index]),
+                Architecture::HiddenSize);
+        }
+    }
+
     AccumulatorStack::AccumulatorStack()
         : m_Entries(std::make_unique<Entries>())
     {
@@ -129,12 +183,11 @@ namespace NeraChessNNUE
                 continue;
             }
 
-            Simd::Copy(child[perspective], parent[perspective], Architecture::HiddenSize);
             child.inputBuckets[Index(perspective)] = static_cast<uint8_t>(bucket);
 
             FeatureSet::FeatureDelta delta;
             FeatureSet::ComputeDelta(dirty, perspective, bucket, delta);
-            child.ApplyDelta(network, delta, perspective);
+            child.ApplyDeltaFrom(network, parent[perspective], delta, perspective);
         }
 
         child.computed = true;

--- a/NeraChessNNUE/src/Accumulator.h
+++ b/NeraChessNNUE/src/Accumulator.h
@@ -58,6 +58,15 @@ namespace NeraChessNNUE
         // accumulator.
         void ApplyDelta(const Network& network, const FeatureSet::FeatureDelta& delta,
             Perspective perspective);
+
+        // Same as ApplyDelta, but reads the starting values from `source`
+        // instead of this accumulator's own (already up to date) values, and
+        // writes the result into this accumulator. Lets a child node's Push
+        // fold the parent-to-child copy into its first delta operation
+        // instead of copying the parent over and then rewriting it in place.
+        // `source` must not alias this perspective's storage.
+        void ApplyDeltaFrom(const Network& network, const Weight* source,
+            const FeatureSet::FeatureDelta& delta, Perspective perspective);
     };
 
     // Upper bound on search depth plus quiescence extensions. Must stay at or

--- a/NeraChessNNUE/src/SimdOps.h
+++ b/NeraChessNNUE/src/SimdOps.h
@@ -73,6 +73,38 @@ namespace NeraChessNNUE::Simd
             }
         }
 
+        // destination[i] = source[i] + column[i]
+        //
+        // Same arithmetic as Add, but reads the running total from a separate
+        // source buffer instead of accumulating in place -- the first delta
+        // operation of a Push can then read the parent accumulator and write
+        // the child directly, instead of copying the parent over first.
+        inline void CopyAdd(Weight* destination, const Weight* source, const Weight* column,
+            size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                destination[index] = static_cast<Weight>(source[index] + column[index]);
+        }
+
+        // destination[i] = source[i] - column[i]
+        inline void CopySubtract(Weight* destination, const Weight* source, const Weight* column,
+            size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                destination[index] = static_cast<Weight>(source[index] - column[index]);
+        }
+
+        // destination[i] = source[i] + added[i] - removed[i]
+        inline void CopyAddSubtract(Weight* destination, const Weight* source,
+            const Weight* added, const Weight* removed, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+            {
+                destination[index] = static_cast<Weight>(
+                    source[index] + added[index] - removed[index]);
+            }
+        }
+
         inline Accumulation ActivatedDotProduct(const Weight* values, const Weight* weights,
             size_t count)
         {
@@ -134,6 +166,67 @@ namespace NeraChessNNUE::Simd
             for (size_t index = 0; index < count; ++index)
                 sum += Quantization::Activate(values[index]) * weights[index];
             return sum;
+        }
+
+        // Add/Subtract/AddSubtract and the Copy* variants below already have a
+        // native SSE2 vector path (unlike ActivatedDotProduct), so there is no
+        // SSE4.1 tier for them: SSE2 already vectorizes this arithmetic and
+        // SSE4.1 adds nothing an AVX2 clone doesn't already give. Each clone
+        // here is the identical scalar loop recompiled at a wider target;
+        // int16 addition/subtraction wraps the same way regardless of lane
+        // width, so every clone is bit-exact with Simd::Scalar by construction
+        // -- there is no reassociation risk the way there is for the dot
+        // product's reduction.
+        __attribute__((target("avx2")))
+        inline void AddAvx2(Weight* accumulator, const Weight* column, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                accumulator[index] = static_cast<Weight>(accumulator[index] + column[index]);
+        }
+
+        __attribute__((target("avx2")))
+        inline void SubtractAvx2(Weight* accumulator, const Weight* column, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                accumulator[index] = static_cast<Weight>(accumulator[index] - column[index]);
+        }
+
+        __attribute__((target("avx2")))
+        inline void AddSubtractAvx2(Weight* accumulator, const Weight* added,
+            const Weight* removed, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+            {
+                accumulator[index] = static_cast<Weight>(
+                    accumulator[index] + added[index] - removed[index]);
+            }
+        }
+
+        __attribute__((target("avx2")))
+        inline void CopyAddAvx2(Weight* destination, const Weight* source, const Weight* column,
+            size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                destination[index] = static_cast<Weight>(source[index] + column[index]);
+        }
+
+        __attribute__((target("avx2")))
+        inline void CopySubtractAvx2(Weight* destination, const Weight* source,
+            const Weight* column, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+                destination[index] = static_cast<Weight>(source[index] - column[index]);
+        }
+
+        __attribute__((target("avx2")))
+        inline void CopyAddSubtractAvx2(Weight* destination, const Weight* source,
+            const Weight* added, const Weight* removed, size_t count)
+        {
+            for (size_t index = 0; index < count; ++index)
+            {
+                destination[index] = static_cast<Weight>(
+                    source[index] + added[index] - removed[index]);
+            }
         }
 
         enum class Tier { Avx2, Sse41, Baseline };
@@ -204,6 +297,13 @@ namespace NeraChessNNUE::Simd
         }
         Scalar::Add(accumulator + index, column + index, count - index);
 #elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::AddAvx2(accumulator, column, count);
+            return;
+        }
+#endif
         size_t index = 0;
         for (; index + 8 <= count; index += 8)
         {
@@ -240,6 +340,13 @@ namespace NeraChessNNUE::Simd
         }
         Scalar::Subtract(accumulator + index, column + index, count - index);
 #elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::SubtractAvx2(accumulator, column, count);
+            return;
+        }
+#endif
         size_t index = 0;
         for (; index + 8 <= count; index += 8)
         {
@@ -286,6 +393,13 @@ namespace NeraChessNNUE::Simd
         }
         Scalar::AddSubtract(accumulator + index, added + index, removed + index, count - index);
 #elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::AddSubtractAvx2(accumulator, added, removed, count);
+            return;
+        }
+#endif
         size_t index = 0;
         for (; index + 8 <= count; index += 8)
         {
@@ -305,6 +419,154 @@ namespace NeraChessNNUE::Simd
     inline void Copy(Weight* destination, const Weight* source, size_t count)
     {
         std::memcpy(destination, source, count * sizeof(Weight));
+    }
+
+    // destination[i] = source[i] + column[i]
+    //
+    // Same shape as Add, but writes a separate destination instead of
+    // accumulating in place -- see Scalar::CopyAdd.
+    inline void CopyAdd(Weight* destination, const Weight* source, const Weight* column,
+        size_t count)
+    {
+#if defined(NNUE_SIMD_NEON)
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            vst1q_s16(destination + index,
+                vaddq_s16(vld1q_s16(source + index), vld1q_s16(column + index)));
+        }
+        Scalar::CopyAdd(destination + index, source + index, column + index, count - index);
+#elif defined(NNUE_SIMD_AVX2)
+        size_t index = 0;
+        for (; index + 16 <= count; index += 16)
+        {
+            const __m256i sum = _mm256_add_epi16(
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(source + index)),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(column + index)));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(destination + index), sum);
+        }
+        Scalar::CopyAdd(destination + index, source + index, column + index, count - index);
+#elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::CopyAddAvx2(destination, source, column, count);
+            return;
+        }
+#endif
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            const __m128i sum = _mm_add_epi16(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(source + index)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(column + index)));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(destination + index), sum);
+        }
+        Scalar::CopyAdd(destination + index, source + index, column + index, count - index);
+#else
+        Scalar::CopyAdd(destination, source, column, count);
+#endif
+    }
+
+    // destination[i] = source[i] - column[i]
+    inline void CopySubtract(Weight* destination, const Weight* source, const Weight* column,
+        size_t count)
+    {
+#if defined(NNUE_SIMD_NEON)
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            vst1q_s16(destination + index,
+                vsubq_s16(vld1q_s16(source + index), vld1q_s16(column + index)));
+        }
+        Scalar::CopySubtract(destination + index, source + index, column + index, count - index);
+#elif defined(NNUE_SIMD_AVX2)
+        size_t index = 0;
+        for (; index + 16 <= count; index += 16)
+        {
+            const __m256i difference = _mm256_sub_epi16(
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(source + index)),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(column + index)));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(destination + index), difference);
+        }
+        Scalar::CopySubtract(destination + index, source + index, column + index, count - index);
+#elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::CopySubtractAvx2(destination, source, column, count);
+            return;
+        }
+#endif
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            const __m128i difference = _mm_sub_epi16(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(source + index)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(column + index)));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(destination + index), difference);
+        }
+        Scalar::CopySubtract(destination + index, source + index, column + index, count - index);
+#else
+        Scalar::CopySubtract(destination, source, column, count);
+#endif
+    }
+
+    // destination[i] = source[i] + added[i] - removed[i]
+    //
+    // The fused replacement for AccumulatorStack::Push's memcpy-then-delta:
+    // reads the parent accumulator once and writes the child directly,
+    // instead of copying the parent over and then rewriting it in place.
+    inline void CopyAddSubtract(Weight* destination, const Weight* source, const Weight* added,
+        const Weight* removed, size_t count)
+    {
+#if defined(NNUE_SIMD_NEON)
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            const int16x8_t updated = vsubq_s16(
+                vaddq_s16(vld1q_s16(source + index), vld1q_s16(added + index)),
+                vld1q_s16(removed + index));
+            vst1q_s16(destination + index, updated);
+        }
+        Scalar::CopyAddSubtract(destination + index, source + index, added + index,
+            removed + index, count - index);
+#elif defined(NNUE_SIMD_AVX2)
+        size_t index = 0;
+        for (; index + 16 <= count; index += 16)
+        {
+            const __m256i updated = _mm256_sub_epi16(
+                _mm256_add_epi16(
+                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(source + index)),
+                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(added + index))),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(removed + index)));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(destination + index), updated);
+        }
+        Scalar::CopyAddSubtract(destination + index, source + index, added + index,
+            removed + index, count - index);
+#elif defined(NNUE_SIMD_SSE2)
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (Dispatch::SelectedTier() == Dispatch::Tier::Avx2)
+        {
+            Dispatch::CopyAddSubtractAvx2(destination, source, added, removed, count);
+            return;
+        }
+#endif
+        size_t index = 0;
+        for (; index + 8 <= count; index += 8)
+        {
+            const __m128i updated = _mm_sub_epi16(
+                _mm_add_epi16(
+                    _mm_loadu_si128(reinterpret_cast<const __m128i*>(source + index)),
+                    _mm_loadu_si128(reinterpret_cast<const __m128i*>(added + index))),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(removed + index)));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(destination + index), updated);
+        }
+        Scalar::CopyAddSubtract(destination + index, source + index, added + index,
+            removed + index, count - index);
+#else
+        Scalar::CopyAddSubtract(destination, source, added, removed, count);
+#endif
     }
 
     // Sum of Activate(values[i]) * weights[i].

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -840,6 +840,71 @@ namespace
 #endif
     }
 
+    // Same idea as RequireDispatchTiersAgree, for the AVX2 dispatch clones of
+    // the accumulator kernels (Add/Subtract/AddSubtract and the Copy*
+    // variants): on an SSE2-baseline x86 build these are runtime-selected, so
+    // exercising Simd::Add et al. alone only tests whichever tier this
+    // machine happens to pick.
+    void RequireAccumulatorDispatchTierAgrees(const Nnue::Weight* accumulator,
+        const Nnue::Weight* added, const Nnue::Weight* removed, size_t length)
+    {
+#if defined(NNUE_SIMD_X86_DISPATCH)
+        if (!__builtin_cpu_supports("avx2"))
+            return;
+
+        std::vector<Nnue::Weight> byDispatch(accumulator, accumulator + length);
+        std::vector<Nnue::Weight> byScalar(accumulator, accumulator + length);
+        Nnue::Simd::Dispatch::AddAvx2(byDispatch.data(), added, length);
+        Nnue::Simd::Scalar::Add(byScalar.data(), added, length);
+        Require(byDispatch == byScalar,
+            "SIMD Add's AVX2 dispatch tier disagrees with the scalar reference at length " +
+                std::to_string(length));
+
+        byDispatch.assign(accumulator, accumulator + length);
+        byScalar.assign(accumulator, accumulator + length);
+        Nnue::Simd::Dispatch::SubtractAvx2(byDispatch.data(), added, length);
+        Nnue::Simd::Scalar::Subtract(byScalar.data(), added, length);
+        Require(byDispatch == byScalar,
+            "SIMD Subtract's AVX2 dispatch tier disagrees with the scalar reference at length " +
+                std::to_string(length));
+
+        byDispatch.assign(accumulator, accumulator + length);
+        byScalar.assign(accumulator, accumulator + length);
+        Nnue::Simd::Dispatch::AddSubtractAvx2(byDispatch.data(), added, removed, length);
+        Nnue::Simd::Scalar::AddSubtract(byScalar.data(), added, removed, length);
+        Require(byDispatch == byScalar,
+            "SIMD AddSubtract's AVX2 dispatch tier disagrees with the scalar reference at "
+            "length " + std::to_string(length));
+
+        std::vector<Nnue::Weight> copyDispatch(length);
+        std::vector<Nnue::Weight> copyScalar(length);
+        Nnue::Simd::Dispatch::CopyAddAvx2(copyDispatch.data(), accumulator, added, length);
+        Nnue::Simd::Scalar::CopyAdd(copyScalar.data(), accumulator, added, length);
+        Require(copyDispatch == copyScalar,
+            "SIMD CopyAdd's AVX2 dispatch tier disagrees with the scalar reference at length " +
+                std::to_string(length));
+
+        Nnue::Simd::Dispatch::CopySubtractAvx2(copyDispatch.data(), accumulator, added, length);
+        Nnue::Simd::Scalar::CopySubtract(copyScalar.data(), accumulator, added, length);
+        Require(copyDispatch == copyScalar,
+            "SIMD CopySubtract's AVX2 dispatch tier disagrees with the scalar reference at "
+            "length " + std::to_string(length));
+
+        Nnue::Simd::Dispatch::CopyAddSubtractAvx2(copyDispatch.data(), accumulator, added,
+            removed, length);
+        Nnue::Simd::Scalar::CopyAddSubtract(copyScalar.data(), accumulator, added, removed,
+            length);
+        Require(copyDispatch == copyScalar,
+            "SIMD CopyAddSubtract's AVX2 dispatch tier disagrees with the scalar reference at "
+            "length " + std::to_string(length));
+#else
+        (void)accumulator;
+        (void)added;
+        (void)removed;
+        (void)length;
+#endif
+    }
+
     void TestNnueSimdKernels()
     {
         // Vector kernels must agree with the scalar reference exactly, not
@@ -908,12 +973,40 @@ namespace
                     "SIMD AddSubtract disagrees with the scalar reference at length " +
                         std::to_string(length));
 
+                const auto compareCopy = [&](std::string_view what,
+                    void (*vector)(Nnue::Weight*, const Nnue::Weight*, const Nnue::Weight*, size_t),
+                    void (*scalar)(Nnue::Weight*, const Nnue::Weight*, const Nnue::Weight*, size_t))
+                {
+                    std::vector<Nnue::Weight> byVector(length);
+                    std::vector<Nnue::Weight> byScalar(length);
+                    vector(byVector.data(), values.data(), added.data(), length);
+                    scalar(byScalar.data(), values.data(), added.data(), length);
+                    Require(byVector == byScalar,
+                        "SIMD " + std::string(what) + " disagrees with the scalar reference at "
+                        "length " + std::to_string(length));
+                };
+                compareCopy("CopyAdd", Nnue::Simd::CopyAdd, Nnue::Simd::Scalar::CopyAdd);
+                compareCopy("CopySubtract", Nnue::Simd::CopySubtract,
+                    Nnue::Simd::Scalar::CopySubtract);
+
+                std::vector<Nnue::Weight> copyFusedVector(length);
+                std::vector<Nnue::Weight> copyFusedScalar(length);
+                Nnue::Simd::CopyAddSubtract(copyFusedVector.data(), values.data(), added.data(),
+                    removed.data(), length);
+                Nnue::Simd::Scalar::CopyAddSubtract(copyFusedScalar.data(), values.data(),
+                    added.data(), removed.data(), length);
+                Require(copyFusedVector == copyFusedScalar,
+                    "SIMD CopyAddSubtract disagrees with the scalar reference at length " +
+                        std::to_string(length));
+
                 Require(Nnue::Simd::ActivatedDotProduct(values.data(), added.data(), length) ==
                     Nnue::Simd::Scalar::ActivatedDotProduct(values.data(), added.data(), length),
                     "SIMD ActivatedDotProduct disagrees with the scalar reference at length " +
                         std::to_string(length));
 
                 RequireDispatchTiersAgree(values.data(), added.data(), length);
+                RequireAccumulatorDispatchTierAgrees(values.data(), added.data(), removed.data(),
+                    length);
             }
         }
 
@@ -927,6 +1020,8 @@ namespace
                 saturated.size()),
             "SIMD ActivatedDotProduct overflows where the scalar reference does not");
         RequireDispatchTiersAgree(saturated.data(), extremeWeights.data(), saturated.size());
+        RequireAccumulatorDispatchTierAgrees(saturated.data(), extremeWeights.data(),
+            extremeWeights.data(), saturated.size());
     }
 
     void TestNnueFeatureIndexing()


### PR DESCRIPTION
Closes #16.

## What this changes

Two independent costs on the hottest path in the engine — `AccumulatorStack::Push`
runs once per `MakeSearchMove`.

**Fuse the copy into the delta pass.** `Push` used to `Simd::Copy` the parent
accumulator into the child and then have `ApplyDelta` immediately read that back
and rewrite it in place, so every push wrote each perspective's 512 weights
twice. `Accumulator::ApplyDeltaFrom` now reads the parent directly in its first
delta operation (`CopyAdd` / `CopySubtract` / `CopyAddSubtract`) and writes the
child in the same pass. The no-delta case still falls back to a plain `Copy`.
This is the fusion `Simd::AddSubtract` already does for the paired add/subtract;
the copy simply wasn't part of it.

**Dispatch the feature-transformer kernels to AVX2.** `Add` / `Subtract` /
`AddSubtract` and the new `Copy*` kernels gain the same runtime dispatch tier
`ActivatedDotProduct` already has on an SSE2-baseline x86-64 build: each clone is
the identical scalar loop recompiled at a wider target, selected once per process
via `__builtin_cpu_supports`, alongside the existing SSE2 path for machines
without AVX2.

## Bit-exactness

Both changes are bit-exact by construction — int16 wraparound is the same
regardless of grouping or lane width — which is the invariant that keeps
multithreaded search deterministic.

That's asserted, not assumed. `NeraChessTests` gains cases comparing every
dispatch tier against the scalar reference across a range of lengths, for `Add`,
`Subtract`, `AddSubtract`, `CopyAdd`, `CopySubtract`, and `CopyAddSubtract`.
Testing `Simd::Add` alone would only exercise whichever tier the host machine
happens to select, so the tests reach each tier explicitly.

Behaviourally the tree is unaffected: a fixed `go depth 9` from a mid-game FEN
produces byte-identical node counts (105,143) and PVs before and after.

## Measurements

Total instructions drop 7.5% (1,496,915,467 -> 1,384,288,455, callgrind, book
resource removed to avoid load noise), which matches the fused-copy plus
AVX2-dispatch mechanism directly.

Strength test, candidate `c1e745a` vs baseline `main` @ `694287c`, 1,000 games at
10+0.1 ([run 32693607556](https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/32693607556)):

| Measurement | Result |
|---|---:|
| Games | 1000 |
| W / L / D | 295 / 259 / 446 |
| Candidate score | 51.80% |
| Estimated Elo | +12.5 |
| Approximate paired 95% interval | [-0.3, +25.3] |
| Pentanomial | [14, 100, 239, 130, 17] |

Stating this plainly: the lower bound is **-0.3**, so the interval does not quite
exclude zero and the harness classifies the run as "promising, but inconclusive."
It is not proof of a positive Elo change on its own. The case for merging rests
mainly on the mechanism — a measured instruction-count reduction from a
provably bit-exact transformation, with no change to the search tree — for which
the game result is corroborating rather than load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)