### PR TITLE
Skip make/unmake for pruned quiescence captures

### DIFF
--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -727,24 +727,24 @@ namespace NeraChessSearch
 
         for (const Move move : candidates)
         {
-            bool deltaPrunable = false;
-            bool seePrunable = false;
             if (!inCheck && !(move.GetMoveFlags() & MoveFlags::IS_PROMOTION))
             {
                 const Piece victim = (move.GetMoveFlags() & MoveFlags::IS_EN_PASSANT)
                     ? Piece(move.GetMovePiece().IsWhite()
                         ? PieceType::BLACK_PAWN : PieceType::WHITE_PAWN)
                     : board.GetPiece(move.GetTargetSquare());
-                deltaPrunable = standPat + PieceValue(victim) + 200 < alpha;
-                seePrunable = MoveOrdering::StaticExchangeEvaluation(board, move) < -50;
+                const bool deltaPrunable = standPat + PieceValue(victim) + 200 < alpha;
+                const bool seePrunable = MoveOrdering::StaticExchangeEvaluation(board, move) < -50;
+
+                // Deciding this before MakeSearchMove avoids paying for the accumulator
+                // push and a full legal-move generation of the child position on a move
+                // that is about to be discarded. GivesCheck answers the same question as
+                // making the move and calling IsInCheck() without either cost.
+                if ((deltaPrunable || seePrunable) && !board.GivesCheck(move))
+                    continue;
             }
 
             MakeSearchMove(board, move);
-            if (!inCheck && !board.IsInCheck() && (deltaPrunable || seePrunable))
-            {
-                UndoSearchMove(board, move);
-                continue;
-            }
             const Score score = -QuiescenceSearch(board, -beta, -alpha, ply + 1);
             UndoSearchMove(board, move);
 


### PR DESCRIPTION
## What this changes

`QuiescenceSearch` decided delta/SEE pruning *after* `MakeSearchMove`, so a
capture that was about to be pruned still paid for the accumulator push and a
full legal move generation of the child position (via `IsInCheck()`) before being
undone. This reorders the decision to before the move is made.

`ChessBoard::GivesCheck` answers the same question from the pre-move position
without either cost. The main search's quiet-move pruning was already converted
to use it (`SearchEngine.cpp:558`); this applies the same pattern to quiescence
capture pruning.

Net diff is 9 lines changed in one file.

## Why this is behaviour-preserving

The old guard was `!board.IsInCheck()` evaluated after the move — since
`MakeSearchMove` flips the side to move, that asks exactly "did this move give
check," which is what `GivesCheck(move)` returns directly.

That equivalence isn't assumed here. `TestGivesCheck`
(`NeraChessTests/src/main.cpp:264`) already walks the tree recursively and
requires `GivesCheck(move)` to agree with make-move-then-`IsInCheck` on every
move it generates, so the property this change leans on is covered by the
existing suite rather than by this PR's own reasoning.

Empirically the tree is untouched: fixed-depth node counts and best moves are
unchanged across a 10-position set at depth 12 — 2,308,678 nodes both before and
after. NPS improved ~9-13% across repeated runs.

## Strength test

Candidate `12c6787` vs baseline `9296f47`, 1,000 games at 10+0.1
([run 32706886588](https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/32706886588)):

| Measurement | Result |
|---|---:|
| Games | 1000 |
| W / L / D | 297 / 265 / 438 |
| Candidate score | 51.60% |
| Estimated Elo | +11.1 |
| Approximate paired 95% interval | [-3.0, +25.3] |
| Pentanomial | [23, 106, 212, 134, 25] |

The baseline is this branch's exact parent, not current `main`. That is
deliberate and is the comparison you want here: `main` has since taken the
16.8B-position network from #20, so testing against today's `main` would have
confounded a search-speed change with a network change. Both sides of this match
ran the identical NNUE file.

Stating the result plainly: the lower bound is **-3.0**, so the interval includes
zero and the harness classifies this as "promising, but inconclusive." It is not
proof of a positive Elo change on its own. The case for merging rests on the
mechanism — identical node counts confirm the search tree is unchanged, so this
is strictly the same search doing less work per node — with the game result as
corroboration rather than the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)