### PR TITLE
Build NeraChessEngine at -O3 and enable LTO on Release/Dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,15 +140,15 @@ jobs:
 
       - name: Make llvm-ar available for LTO archiving
         # Premake's gmake action switches the archiver to llvm-ar for the
-        # clang toolset once linktimeoptimization is enabled. Xcode ships
-        # llvm-ar alongside clang in its toolchain directory, but only
-        # `clang`/`ar`/`ranlib` are symlinked onto the default PATH.
-        # Adding that whole toolchain directory to PATH would shadow the
-        # /usr/bin/clang wrapper that resolves the SDK sysroot, breaking
-        # every compile, so symlink just the missing tool instead.
+        # clang toolset once linktimeoptimization is enabled. GitHub's
+        # macOS runner does not ship llvm-ar as a standalone tool at all
+        # (xcrun --find llvm-ar fails with "not a developer tool or in
+        # PATH"), but Apple's own ar/ranlib already index LLVM bitcode
+        # natively, so forward llvm-ar to the system ar instead.
         run: |
           mkdir -p "$RUNNER_TEMP/llvm-ar-shim"
-          ln -sf "$(xcrun --find llvm-ar)" "$RUNNER_TEMP/llvm-ar-shim/llvm-ar"
+          printf '#!/bin/sh\nexec ar "$@"\n' > "$RUNNER_TEMP/llvm-ar-shim/llvm-ar"
+          chmod +x "$RUNNER_TEMP/llvm-ar-shim/llvm-ar"
           echo "$RUNNER_TEMP/llvm-ar-shim" >> "$GITHUB_PATH"
 
       - name: Generate Makefiles

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,13 @@ jobs:
       - name: Install dependencies
         run: brew install premake sdl2-compat sdl2_image sdl2_mixer
 
+      - name: Make llvm-ar available for LTO archiving
+        # Premake's gmake action switches the archiver to llvm-ar for the
+        # clang toolset once linktimeoptimization is enabled. Xcode ships
+        # llvm-ar alongside clang in its toolchain directory, but only
+        # `clang`/`ar`/`ranlib` are symlinked onto the default PATH.
+        run: echo "$(dirname "$(xcrun --find clang)")" >> "$GITHUB_PATH"
+
       - name: Generate Makefiles
         run: ./scripts/Setup-macOS.sh gmake
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,13 @@ jobs:
         # clang toolset once linktimeoptimization is enabled. Xcode ships
         # llvm-ar alongside clang in its toolchain directory, but only
         # `clang`/`ar`/`ranlib` are symlinked onto the default PATH.
-        run: echo "$(dirname "$(xcrun --find clang)")" >> "$GITHUB_PATH"
+        # Adding that whole toolchain directory to PATH would shadow the
+        # /usr/bin/clang wrapper that resolves the SDK sysroot, breaking
+        # every compile, so symlink just the missing tool instead.
+        run: |
+          mkdir -p "$RUNNER_TEMP/llvm-ar-shim"
+          ln -sf "$(xcrun --find llvm-ar)" "$RUNNER_TEMP/llvm-ar-shim/llvm-ar"
+          echo "$RUNNER_TEMP/llvm-ar-shim" >> "$GITHUB_PATH"
 
       - name: Generate Makefiles
         run: ./scripts/Setup-macOS.sh gmake

--- a/NeraChessEngine/Build-NeraChessEngine.lua
+++ b/NeraChessEngine/Build-NeraChessEngine.lua
@@ -47,12 +47,14 @@ project "NeraChessEngine"
   filter "configurations:Release"
     defines { "RELEASE" }
     runtime "Release"
-    optimize "On"
+    optimize "Speed"
     symbols "On"
+    linktimeoptimization "On"
 
   filter "configurations:Dist"
     defines { "DIST" }
     runtime "Release"
-    optimize "On"
+    optimize "Speed"
     symbols "Off"
+    linktimeoptimization "On"
   filter {}

--- a/NeraChessNNUE/Build-NeraChessNNUE.lua
+++ b/NeraChessNNUE/Build-NeraChessNNUE.lua
@@ -44,10 +44,12 @@ project "NeraChessNNUE"
     runtime "Release"
     optimize "Speed"
     symbols "On"
+    linktimeoptimization "On"
 
   filter "configurations:Dist"
     defines { "DIST" }
     runtime "Release"
     optimize "Speed"
     symbols "Off"
+    linktimeoptimization "On"
   filter {}

--- a/NeraChessSearch/Build-NeraChessSearch.lua
+++ b/NeraChessSearch/Build-NeraChessSearch.lua
@@ -49,10 +49,12 @@ project "NeraChessSearch"
     runtime "Release"
     optimize "Speed"
     symbols "On"
+    linktimeoptimization "On"
 
   filter "configurations:Dist"
     defines { "DIST" }
     runtime "Release"
     optimize "Speed"
     symbols "Off"
+    linktimeoptimization "On"
   filter {}

--- a/NeraChessTests/Build-NeraChessTests.lua
+++ b/NeraChessTests/Build-NeraChessTests.lua
@@ -52,10 +52,12 @@ project "NeraChessTests"
     runtime "Release"
     optimize "Speed"
     symbols "On"
+    linktimeoptimization "On"
 
   filter "configurations:Dist"
     defines { "DIST" }
     runtime "Release"
     optimize "Speed"
     symbols "Off"
+    linktimeoptimization "On"
   filter {}

--- a/NeraChessUCI/Build-NeraChessUCI.lua
+++ b/NeraChessUCI/Build-NeraChessUCI.lua
@@ -63,10 +63,12 @@ project "NeraChessUCI"
     runtime "Release"
     optimize "Speed"
     symbols "On"
+    linktimeoptimization "On"
 
   filter "configurations:Dist"
     defines { "DIST" }
     runtime "Release"
     optimize "Speed"
     symbols "Off"
+    linktimeoptimization "On"
   filter {}


### PR DESCRIPTION
Closes #21.

## What this changes

`NeraChessEngine` was the only headless layer still built at `optimize "On"`
(-O2), despite move generation being the largest single share of search
instructions. Separately, no layer set `linktimeoptimization`, so small
primitives defined out of line — `Move`'s constructor, `BitUtil`, `Square`
accessors, `ChessBoard::GetPiece` — paid a real call/ret across the static
library boundaries separating `NeraChessEngine`, `NeraChessNNUE`,
`NeraChessSearch`, and `NeraChessUCI`.

This raises `NeraChessEngine` to `optimize "Speed"` and turns on
`linktimeoptimization` for Release and Dist across the headless layers, letting
those primitives inline across the library boundaries. Debug is untouched, so
the accumulator full-refresh asserts and sanitizer jobs are unaffected.

The remaining three commits fix the macOS CI fallout: enabling
`linktimeoptimization` makes Premake's gmake action switch the archiver to
`llvm-ar` for the clang toolset, and GitHub's macOS runner does not ship
`llvm-ar` as a standalone tool at all. Apple's `ar`/`ranlib` already index LLVM
bitcode natively, so the workflow shims `llvm-ar` to forward to the system `ar`.
All three build jobs are green.

## Strength test

Candidate `1cbe53f` vs baseline `9296f47`, 1,000 games at 10+0.1
([run 32815504512](https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/32815504512)):

| Measurement | Result |
|---|---:|
| Games | 1000 |
| W / L / D | 383 / 196 / 421 |
| Candidate score | 59.35% |
| Estimated Elo | **+65.7** |
| Approximate paired 95% interval | **[+52.0, +79.7]** |
| Pentanomial | [7, 65, 209, 172, 47] |

The interval excludes zero by a wide margin — the harness classifies this as a
likely improvement, and it is the first candidate in this series to clear that
bar outright rather than on mechanism alone.

The magnitude is large for a compiler-flag change, so it is worth noting that the
two independent measurements corroborate each other rather than resting on one
number. Locally, `--bench` perft NPS went from 52.2M to 118.1M — a ~2.3x
speedup. A doubling of search speed is conventionally worth somewhere around
+60-70 Elo at fast time controls, which is where this result landed. The
speedup and the Elo are consistent explanations of the same cause.

Baseline is this branch's point of divergence, not current `main`, because `main`
has since taken the 16.8B-position network from #20; testing against it would
have confounded compiler flags with a network change. The NNUE file is
byte-identical on both sides of this match, so `Run-Match.sh`'s network-mismatch
guard stayed armed. This is the same baseline #22 used, so the two results are
directly comparable.

## Determinism and correctness

Unlike #19 and #22, this change is *not* bit-exact by construction. Those rested
on provably identical arithmetic; this one rests on the compiler preserving
program semantics under whole-program optimization, which is a weaker guarantee.
Worth stating plainly rather than glossing.

What backs it up:

- Fixed-depth node counts and best moves are unchanged locally — 1,002,119 nodes
  and identical bestmoves across 8 positions at depth 11.
- Because `NeraChessTests` is itself a Release target, it is now built *with* LTO,
  and CI runs it both at baseline and rebuilt with `-mavx2`. The NNUE cases that
  require the scalar/SSE2/AVX2 kernels to agree bit-for-bit therefore execute
  under LTO, which is the invariant that keeps multithreaded search
  deterministic.
- The NNUE kernels are integer, so there is no floating-point contraction risk
  from `-O3` reassociation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)