### PR TITLE
Defer move generation to nodes that actually need it

### DIFF
--- a/NeraChessEngine/src/ChessBoard.cpp
+++ b/NeraChessEngine/src/ChessBoard.cpp
@@ -604,6 +604,11 @@ namespace NeraChessEngine
 
 	MoveList<218> ChessBoard::GetLegalMoves() const
 	{
+		return GetLegalMovesRef();
+	}
+
+	const MoveList<218>& ChessBoard::GetLegalMovesRef() const
+	{
 		if (m_WasBoardStateChanged)
 		{
 			m_LegalMoves = m_MoveGenerator.GenerateMoves(m_BoardState);
@@ -902,12 +907,62 @@ namespace NeraChessEngine
 
 	bool ChessBoard::IsInCheck() const
 	{
+		const bool whiteToMove = m_BoardState.HasFlag(BoardStateFlags::WhiteToMove);
+		const uint8_t friendlyOffset = whiteToMove ? 0 : 6;
+		const uint8_t enemyOffset = whiteToMove ? 6 : 0;
+
+		const Bitboard king = m_BoardState.pieceBitboards[friendlyOffset + PieceType::WHITE_KING];
+		if (!king)
+			return false;
+		const uint8_t kingSquare = BitUtil::GetLSBIndex(king);
+
+		Bitboard occupancy = 0;
+		for (const Bitboard pieceSet : m_BoardState.pieceBitboards)
+			occupancy |= pieceSet;
+
+		const Bitboard enemyPawns = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_PAWN];
+		const Bitboard pawnCheckers = whiteToMove
+			? MoveGenerator::s_WhitePawnAttackMasks[kingSquare]
+			: MoveGenerator::s_BlackPawnAttackMasks[kingSquare];
+		if (pawnCheckers & enemyPawns)
+			return true;
+
+		const Bitboard enemyKnights = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_KNIGHT];
+		if (MoveGenerator::s_KnightMoveMask[kingSquare] & enemyKnights)
+			return true;
+
+		const Bitboard enemyBishops = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_BISHOP];
+		const Bitboard enemyRooks = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_ROOK];
+		const Bitboard enemyQueens = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_QUEEN];
+		if (MoveGenerator::LookupBishopAttacks(kingSquare, occupancy) & (enemyBishops | enemyQueens))
+			return true;
+		if (MoveGenerator::LookupRookAttacks(kingSquare, occupancy) & (enemyRooks | enemyQueens))
+			return true;
+
+		const Bitboard enemyKing = m_BoardState.pieceBitboards[enemyOffset + PieceType::WHITE_KING];
+		if (MoveGenerator::s_KingMoveMask[kingSquare] & enemyKing)
+			return true;
+
+		return false;
+	}
+
+	bool ChessBoard::IsInCheckByMoveGeneration() const
+	{
 		if (m_WasBoardStateChanged)
 		{
 			m_LegalMoves = m_MoveGenerator.GenerateMoves(m_BoardState);
 			m_WasBoardStateChanged = false;
 		}
 		return m_MoveGenerator.InCheck();
+	}
+
+	bool ChessBoard::IsRuleDraw() const
+	{
+		if (m_HalfMoveClock >= 100)
+			return true;
+		if (m_RepetitionTable.GetRepetitionCount(GetRepetitionKey(), m_HalfMoveClock) >= 3)
+			return true;
+		return InsufficentMaterial(*this);
 	}
 
 	bool ChessBoard::GivesCheck(Move move) const

--- a/NeraChessEngine/src/ChessBoard.h
+++ b/NeraChessEngine/src/ChessBoard.h
@@ -47,6 +47,11 @@ namespace NeraChessEngine
 
         MoveList<218> GetLegalMoves() const;
 
+	    // Same legal moves as GetLegalMoves(), without the ~880-byte copy -- for
+	    // callers that only read the list (e.g. filtering into a shorter list) and
+	    // never hold onto it past the next move made on this board.
+	    const MoveList<218>& GetLegalMovesRef() const;
+
         void MakeMove(Move move, bool gameMove = false);
 	    void UndoMove(Move move);
 
@@ -59,7 +64,17 @@ namespace NeraChessEngine
 	    uint16_t GetFullMoveClock() const { return m_FullMoves; }
 
         Piece GetPiece(const uint8_t square) const;
+
+	    // Attack-table lookup: whether the side to move's king is attacked, without
+	    // generating the legal move list. Existing callers relied on IsInCheck() to
+	    // force move generation as a side effect; none of them need that list at the
+	    // point they call it, so this is a strict improvement rather than a behavior
+	    // change.
         bool IsInCheck() const;
+
+	    // Reference implementation of IsInCheck(), kept only so the attack-table
+	    // version above can be verified against it exhaustively in tests.
+	    bool IsInCheckByMoveGeneration() const;
 
 	    // Reports whether a legal move would check the opponent, without making it.
 	    // Making the move and calling IsInCheck() answers the same question but forces
@@ -68,6 +83,12 @@ namespace NeraChessEngine
 	    bool GivesCheck(Move move) const;
 
         uint16_t GetGameOver(bool gameCheck = true) const;
+
+	    // Reports the draw conditions that do not require a legal move list: the
+	    // 50-move rule, threefold repetition, and insufficient material. Does not
+	    // detect checkmate or stalemate -- a caller needing those still has to
+	    // generate moves and check for an empty list.
+	    bool IsRuleDraw() const;
 
         uint64_t GetZobristKey() const;
 		uint8_t GetZobristEnPassantFile() const;

--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -430,9 +430,16 @@ namespace NeraChessSearch
         m_SelectiveDepth = std::max(m_SelectiveDepth, ply);
         m_PvLength[ply] = ply;
 
-        Score terminalScore;
-        if (IsDrawOrTerminal(board, terminalScore, ply))
-            return terminalScore;
+        // Cheap draw test first: it needs no move list, unlike checkmate/stalemate
+        // detection below. This must run regardless of check status -- a position
+        // can be in check, have legal replies, and still be a repetition or
+        // 50-move draw, and that is the common case for a repeated check. The only
+        // conflict with checkmate is a mating move landing exactly on halfmove
+        // 100, which this reports as a draw; that is deliberately accepted rather
+        // than paying for a move list on every node to rule it out.
+        if (board.IsRuleDraw())
+            return SCORE_DRAW;
+        const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
             return EvaluateNode(board);
 
@@ -462,7 +469,6 @@ namespace NeraChessSearch
             }
         }
 
-        const bool inCheck = board.IsInCheck();
         const bool mateBounds = beta <= -SCORE_MATE + MAX_PLY ||
             beta >= SCORE_MATE - MAX_PLY;
 
@@ -522,6 +528,8 @@ namespace NeraChessSearch
 
         const Score originalAlpha = alpha;
         MoveList<218> moves = board.GetLegalMoves();
+        if (moves.size() == 0)
+            return inCheck ? -SCORE_MATE + ply : SCORE_DRAW;
         SortMoves(board, moves, ply, ttMove, previousMove);
 
         Score bestScore = -SCORE_INF;
@@ -666,9 +674,9 @@ namespace NeraChessSearch
         m_SelectiveDepth = std::max(m_SelectiveDepth, ply);
         m_PvLength[ply] = ply;
 
-        Score terminalScore;
-        if (IsDrawOrTerminal(board, terminalScore, ply))
-            return terminalScore;
+        if (board.IsRuleDraw())
+            return SCORE_DRAW;
+        const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
             return EvaluateNode(board);
 
@@ -697,7 +705,6 @@ namespace NeraChessSearch
         }
 
         const Score originalAlpha = alpha;
-        const bool inCheck = board.IsInCheck();
         Score bestScore = -SCORE_INF;
         Move bestMove = 0;
         Score standPat = -SCORE_INF;
@@ -717,8 +724,12 @@ namespace NeraChessSearch
             alpha = std::max(alpha, bestScore);
         }
 
+        const MoveList<218>& legalMoves = board.GetLegalMovesRef();
+        if (legalMoves.size() == 0)
+            return inCheck ? -SCORE_MATE + ply : SCORE_DRAW;
+
         MoveList<218> candidates;
-        for (const Move move : board.GetLegalMoves())
+        for (const Move move : legalMoves)
         {
             if (inCheck || !IsQuiet(move))
                 candidates.push(move);

--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -441,7 +441,15 @@ namespace NeraChessSearch
             return SCORE_DRAW;
         const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
+        {
+            // The horizon is deep enough that reaching it at all is exceptional
+            // (a long forcing sequence of checks/extensions), but a move list is
+            // still required to tell an ordinary position from checkmate/stalemate
+            // here -- there is no cutoff left to defer it behind.
+            if (board.GetLegalMoves().size() == 0)
+                return inCheck ? -SCORE_MATE + ply : SCORE_DRAW;
             return EvaluateNode(board);
+        }
 
         alpha = std::max(alpha, -SCORE_MATE + ply);
         beta = std::min(beta, SCORE_MATE - ply - 1);
@@ -678,7 +686,13 @@ namespace NeraChessSearch
             return SCORE_DRAW;
         const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
+        {
+            // See the matching comment in PrincipalVariationSearch: the horizon
+            // has no cutoff left to defer this behind.
+            if (board.GetLegalMoves().size() == 0)
+                return inCheck ? -SCORE_MATE + ply : SCORE_DRAW;
             return EvaluateNode(board);
+        }
 
         alpha = std::max(alpha, -SCORE_MATE + ply);
         beta = std::min(beta, SCORE_MATE - ply - 1);

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -163,28 +163,38 @@ namespace
         ChessBoard checkmate("7k/6Q1/6K1/8/8/8/8/8 b - - 0 1");
         const uint16_t mateFlags = checkmate.GetGameOver();
         Require((mateFlags & IS_CHECKMATE) != 0, "checkmate was not detected");
+        Require(checkmate.IsInCheck(), "fast IsInCheck missed the checking side of a checkmate");
 
         ChessBoard stalemate("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
         const uint16_t staleFlags = stalemate.GetGameOver();
         Require((staleFlags & IS_STALEMATE) != 0, "stalemate was not detected");
+        Require(!stalemate.IsInCheck(), "fast IsInCheck flagged a stalemate as check");
+        Require(!stalemate.IsRuleDraw(),
+            "IsRuleDraw fired on stalemate, which needs move generation to detect");
 
         ChessBoard insufficient("7k/8/8/8/8/8/8/K7 w - - 0 1");
         const uint16_t materialFlags = insufficient.GetGameOver();
         Require((materialFlags & IS_INSUFFICIENT_MATERIAL) != 0, "insufficient material was not detected");
+        Require(insufficient.IsRuleDraw(), "IsRuleDraw missed insufficient material");
 
         ChessBoard sameColorBishops("7k/8/8/8/5b2/8/3B4/K7 w - - 0 1");
         Require((sameColorBishops.GetGameOver() & IS_INSUFFICIENT_MATERIAL) != 0,
             "same-color bishop dead position was not detected");
+        Require(sameColorBishops.IsRuleDraw(), "IsRuleDraw missed a same-color-bishop dead position");
 
         ChessBoard oppositeColorBishops("7k/8/8/8/4b3/8/3B4/K7 w - - 0 1");
         Require((oppositeColorBishops.GetGameOver() & IS_INSUFFICIENT_MATERIAL) == 0,
             "opposite-color bishops were incorrectly declared insufficient");
+        Require(!oppositeColorBishops.IsRuleDraw(),
+            "IsRuleDraw incorrectly declared opposite-color bishops insufficient");
 
         ChessBoard notYetFifty("7k/8/8/8/8/8/R7/K7 w - - 99 1");
         Require((notYetFifty.GetGameOver() & IS_50MOVE_RULE) == 0, "50-move draw was declared one ply early");
+        Require(!notYetFifty.IsRuleDraw(), "IsRuleDraw fired on the 50-move rule one ply early");
         const auto quietMove = notYetFifty.GetLegalMoves()[0];
         notYetFifty.MakeMove(quietMove);
         Require((notYetFifty.GetGameOver() & IS_50MOVE_RULE) != 0, "50-move draw was not declared at 100 halfmoves");
+        Require(notYetFifty.IsRuleDraw(), "IsRuleDraw did not fire at 100 halfmoves");
     }
 
     NeraChessEngine::Move FindMove(const ChessBoard& board, std::string_view uci)
@@ -209,6 +219,7 @@ namespace
                 board.MakeMove(FindMove(board, uci), true);
         }
         Require((board.GetGameOver(true) & IS_REPETITION) != 0, "threefold repetition was not detected");
+        Require(board.IsRuleDraw(), "IsRuleDraw missed threefold repetition");
 
         ChessBoard rights("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
         static constexpr std::string_view rookCycle[] = { "h1h2", "h8h7", "h2h1", "h7h8" };
@@ -219,6 +230,8 @@ namespace
         }
         Require((rights.GetGameOver(true) & IS_REPETITION) == 0,
             "positions with different castling rights were treated as repetitions");
+        Require(!rights.IsRuleDraw(),
+            "IsRuleDraw treated positions with different castling rights as repetitions");
 
         ChessBoard irrelevantEp("4k3/8/8/8/4P3/8/8/4K3 b - e3 0 1");
         ChessBoard noEp("4k3/8/8/8/4P3/8/8/4K3 b - - 0 1");
@@ -294,6 +307,53 @@ namespace
         {
             ChessBoard board{ std::string(fen) };
             CompareGivesCheckAgainstMakeMove(board, 3);
+        }
+    }
+
+    // ChessBoard::IsInCheck() is an attack-table lookup that answers the same
+    // question as the move generator's own InCheck() flag, without generating the
+    // legal move list. The search relies on the two never disagreeing -- a
+    // disagreement would silently break checkmate detection or the pruning that
+    // is gated on being in check -- so it is compared against
+    // IsInCheckByMoveGeneration() (the old, move-generation-based implementation,
+    // kept only for this) over every position of a small tree.
+    void CompareFastInCheckAgainstMoveGeneration(ChessBoard& board, int depth)
+    {
+        Require(board.IsInCheck() == board.IsInCheckByMoveGeneration(),
+            "fast IsInCheck disagreed with the move-generation reference");
+        if (depth <= 0)
+            return;
+        for (const auto move : board.GetLegalMoves())
+        {
+            board.MakeMove(move);
+            Require(board.IsInCheck() == board.IsInCheckByMoveGeneration(),
+                "fast IsInCheck disagreed with the move-generation reference");
+            CompareFastInCheckAgainstMoveGeneration(board, depth - 1);
+            board.UndoMove(move);
+        }
+    }
+
+    void TestFastInCheck()
+    {
+        static constexpr std::string_view positions[] = {
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+            "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+            // En passant, promotion and castling are the three cases where the board
+            // after the move differs from "piece moves from A to B".
+            "8/8/1k6/2b5/2pP4/8/5K2/8 b - d3 0 1",
+            "4k3/1P6/8/8/8/8/6p1/4K3 w - - 0 1",
+            "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+            "8/8/8/8/1k6/8/2P5/4K2R w K - 0 1",
+            "7k/6Q1/6K1/8/8/8/8/8 b - - 0 1",
+            "7k/5Q2/6K1/8/8/8/8/8 b - - 0 1",
+        };
+
+        for (const auto fen : positions)
+        {
+            ChessBoard board{ std::string(fen) };
+            CompareFastInCheckAgainstMoveGeneration(board, 3);
         }
     }
 
@@ -1848,6 +1908,7 @@ int main(int argc, char** argv)
         TestRepetition();
         TestIncrementalZobrist();
         TestGivesCheck();
+        TestFastInCheck();
         TestNullMoveState();
         TestTranspositionTable();
         TestConcurrentTranspositionTable();


### PR DESCRIPTION
## Summary

`PrincipalVariationSearch` and `QuiescenceSearch` generate the full legal move list unconditionally at the top of every node, before the TT probe, reverse futility, null move, and quiescence stand-pat cutoffs that frequently return without ever reading a move. This defers move generation until a node actually survives every cutoff that doesn't need it, following up on the "Part A" quiescence-pruning reorder already shipped in #22.

Closes #11.

## Problem

Every node paid for `ChessBoard::GetGameOver(true)` / `IsInCheck()` up front, both of which unconditionally call `MoveGenerator::GenerateMoves`. That cost was paid even for nodes that immediately return via a TT cutoff, reverse futility, a null-move cutoff, or quiescence stand-pat -- exactly the paths issue #11 measured as ~50% of quiescence nodes and roughly half of PVS nodes.

## Implementation

- `ChessBoard::IsInCheck()` is now an attack-table lookup (pawn/knight/king masks plus the existing magic-bitboard slider lookups) that answers whether the side to move's king is attacked, without touching the move generator. The old move-generation-based implementation is kept as `IsInCheckByMoveGeneration()`, used only as a reference for testing.
- A new `ChessBoard::IsRuleDraw()` reports the draw conditions that don't need a move list -- 50-move rule, threefold repetition, insufficient material -- leaving checkmate/stalemate to be resolved from the generated list's emptiness once a node actually reaches move generation.
- `PrincipalVariationSearch` and `QuiescenceSearch` no longer call `IsDrawOrTerminal` (still used, unchanged, for the one-time root check in `SearchWorker`). Their prologues now run: `IsRuleDraw()` -> cheap `IsInCheck()` -> mate-distance clamp -> TT probe -> static eval / reverse futility / null move / stand-pat -> **generate** -> resolve checkmate/stalemate from an empty list -> sort/search moves.
- `ChessBoard::GetLegalMovesRef()` returns the cached move list by reference; quiescence's capture/check filter uses it to avoid an ~880-byte copy of a list it only reads.

## Why this approach

The draw test has to fire regardless of check status. My first version gated it on `!inCheck` on the reasoning that checkmate needs an empty move list to detect and "in check" implied that path -- but a position can be in check, have legal replies, and still be a repetition or 50-move draw, which is the common case for a repeated line of checks. Gating on `!inCheck` silently stopped detecting that and inflated node counts by >30% on a repeated-check endgame in local testing before the fix; the corrected version checks `IsRuleDraw()` unconditionally and accepts a much narrower edge case instead (a mate delivered by a move that also lands the halfmove clock on exactly 100 is reported as a draw), matching the tolerance the issue itself sets for the analogous stalemate case.

## Validation

```
Release regression suite (no network): PASS
Release regression suite (--eval-file nera.nnue): PASS
Debug regression suite (--eval-file nera.nnue, accumulator asserts active): PASS
--bench (perft to depth 6 from startpos): 119,060,324 nodes, matches known count
```

Added to the regression suite:
- `TestFastInCheck`: exhaustive `IsInCheck()` vs `IsInCheckByMoveGeneration()` comparison over a small tree from 10 seed FENs.
- `IsRuleDraw()` checked against the existing `GetGameOver` fixtures in `TestTerminalPositions`/`TestRepetition` (50-move, repetition, insufficient material, and the negative cases).

A standalone deep walk (depth 5 from 13 seed FENs, including the exact endgame positions used in the fixed-depth benchmark below) checked **376,234,995 positions** with **zero disagreements** between the fast `IsInCheck()` and the move-generation reference.

Fixed-depth comparison (`go depth 13`, single thread, book off, 64 MiB hash, `nera.nnue`, 10 positions covering openings/middlegames/drawish endgames):

| | baseline (3f32041) | candidate (92ce030) |
|---|---:|---:|
| Total nodes | 3,637,117 | 3,637,292 (+0.005%) |
| Best moves | -- | identical on all 10 positions |
| NPS (repeated runs) | ~772k-816k | ~873k-940k (+13% to +16%) |

The tiny node delta is the accepted stalemate/checkmate-adjacent edge case described above; it is not a tree-shape change.

## Strength test

Screening test per `docs/Strength-Testing.md`, 1,000 games at `10+0.1`, paired openings with reversed colors, 4 shards:

```
Candidate: 92ce030f2cd24dff35aa11632f65c087e0c5c92c
Baseline:  3f32041e8fef134435e81fac7c477018a9993a2c
W/D/L: 316 / 450 / 234
Candidate score: 54.10%
Estimated Elo: +28.6
Approximate paired 95% interval: [+14.9, +42.3]
Verdict: Likely improvement
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/33018830280
```

The interval is entirely above zero, but this is a screening result over 1,000 games, not proof of the exact Elo gain -- a longer test would narrow it further if that's ever needed.

## Risks

- The accepted edge case above (a mate landing exactly on halfmove 100, or a stand-pat/RFP/null-move/TT cutoff returning a non-terminal score for a position that also happens to be stalemate) trades a small, quantified inaccuracy for not paying for a move list on every node. Both are extremely rare and the strength test result already reflects their net effect.
- `IsInCheck()` is now new code on the hottest path in the engine (TT probe gating, RFP, null move, LMR all read it). It is verified exhaustively above, but any future change to piece movement rules would need to keep it in sync with the move generator's own check logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Etb3hFAQjfnkF5VbsyDX7E)_