### PR TITLE
Score in-tree repetitions as draws in search

### DIFF
--- a/NeraChessEngine/src/ChessBoard.cpp
+++ b/NeraChessEngine/src/ChessBoard.cpp
@@ -1,5 +1,6 @@
 #include "ChessBoard.h"
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <cstdint>
@@ -682,6 +683,17 @@ namespace NeraChessEngine
 	uint64_t ChessBoard::GetRepetitionKey() const
 	{
 		return GetZobristKey();
+	}
+
+	std::size_t ChessBoard::GetRepetitionPlies() const
+	{
+		return m_RepetitionTable.Size();
+	}
+
+	bool ChessBoard::RepeatsWithin(std::size_t distance) const
+	{
+		return m_RepetitionTable.GetRepetitionCount(GetRepetitionKey(),
+			std::min<std::size_t>(distance, m_HalfMoveClock)) >= 2;
 	}
 
 	uint8_t ChessBoard::GetZobristEnPassantFile() const

--- a/NeraChessEngine/src/ChessBoard.h
+++ b/NeraChessEngine/src/ChessBoard.h
@@ -90,6 +90,18 @@ namespace NeraChessEngine
 	    // generate moves and check for an empty list.
 	    bool IsRuleDraw() const;
 
+	    // Number of positions recorded for repetition detection so far (see
+	    // RepetitionTable::Size). Search uses this, rather than its own ply
+	    // counter, to measure distance back to its root.
+	    std::size_t GetRepetitionPlies() const;
+
+	    // Whether the current position has occurred at least once more within
+	    // `distance` plies before it (same side to move, i.e. every second ply),
+	    // counting the current position itself. This is the in-tree "twofold"
+	    // test the search uses to score a repetition as a draw before a
+	    // game-rule threefold (see GetGameOver) would fire.
+	    bool RepeatsWithin(std::size_t distance) const;
+
         uint64_t GetZobristKey() const;
 		uint8_t GetZobristEnPassantFile() const;
         std::string GetFENString() const;

--- a/NeraChessEngine/src/RepetitionTable.h
+++ b/NeraChessEngine/src/RepetitionTable.h
@@ -19,6 +19,12 @@ namespace NeraChessEngine
 
             uint16_t GetRepetitionCount(uint64_t positionKey, std::size_t reversiblePlies) const;
 
+			// Number of positions recorded: the game history the table was built from,
+			// plus every move made on it since. Search uses this to measure distance
+			// back to its root without relying on ply counters, which a null move
+			// leaves unadvanced.
+			std::size_t Size() const { return m_Keys.size(); }
+
 		void Clear();
 
 		bool operator==(const RepetitionTable& other) const;

--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -234,6 +234,7 @@ namespace NeraChessSearch
         }
 
         ChessBoard board = position;
+        m_RootRepetitionPlies = board.GetRepetitionPlies();
         m_Network = &NeraChessNNUE::Evaluator::GetNetwork();
         m_Accumulators.Reset(*m_Network, board.GetBoardState());
 
@@ -436,8 +437,11 @@ namespace NeraChessSearch
         // 50-move draw, and that is the common case for a repeated check. The only
         // conflict with checkmate is a mating move landing exactly on halfmove
         // 100, which this reports as a draw; that is deliberately accepted rather
-        // than paying for a move list on every node to rule it out.
-        if (board.IsRuleDraw())
+        // than paying for a move list on every node to rule it out. The in-tree
+        // repetition test runs first: it scores a cycle as a draw the first time
+        // it repeats since the root, rather than waiting for IsRuleDraw's
+        // game-rule threefold.
+        if (IsInTreeRepetition(board, ply) || board.IsRuleDraw())
             return SCORE_DRAW;
         const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
@@ -682,7 +686,9 @@ namespace NeraChessSearch
         m_SelectiveDepth = std::max(m_SelectiveDepth, ply);
         m_PvLength[ply] = ply;
 
-        if (board.IsRuleDraw())
+        // See the matching comment in PrincipalVariationSearch for the in-tree
+        // repetition test.
+        if (IsInTreeRepetition(board, ply) || board.IsRuleDraw())
             return SCORE_DRAW;
         const bool inCheck = board.IsInCheck();
         if (ply >= MAX_PLY - 1)
@@ -943,6 +949,30 @@ namespace NeraChessSearch
             ? -SCORE_MATE + ply
             : SCORE_DRAW;
         return true;
+    }
+
+    bool SearchEngine::IsInTreeRepetition(const ChessBoard& board, int ply) const
+    {
+        // The root itself is never a draw just because the position has occurred
+        // before -- only a repetition that happens again inside the tree counts.
+        if (ply <= 0)
+            return false;
+
+        // Distance from `board` back to the search root, measured off the
+        // repetition-key stack rather than `ply`: MakeNullMove pushes no key, so
+        // after a null move the two diverge and a ply-derived bound would read
+        // past the root.
+        const std::size_t plies = board.GetRepetitionPlies();
+        if (plies <= m_RootRepetitionPlies + 1)
+            return false;
+
+        // Bounding the scan to pliesSinceRoot - 1 (rather than pliesSinceRoot)
+        // excludes the root's own occurrence from the match: repeating the root
+        // once is not yet the in-tree cycle this is meant to catch, and still
+        // needs an ordinary threefold. RepeatsWithin itself requires a second,
+        // earlier occurrence of the current position within that window --
+        // i.e. a genuine repetition, not just distance from the root.
+        return board.RepeatsWithin(plies - m_RootRepetitionPlies - 1);
     }
 
     Score SearchEngine::ScoreToTT(Score score, int ply)

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -116,6 +116,11 @@ namespace NeraChessSearch
 
         bool ShouldStop();
         bool IsDrawOrTerminal(const NeraChessEngine::ChessBoard& board, Score& terminalScore, int ply) const;
+        // In-tree repetition test: whether `board` has already occurred once since
+        // the search root, scored as a draw rather than waiting for the game-rule
+        // threefold. See the definition for why distance to root is measured off
+        // the repetition-key stack rather than `ply`.
+        bool IsInTreeRepetition(const NeraChessEngine::ChessBoard& board, int ply) const;
         static Score ScoreToTT(Score score, int ply);
         static Score ScoreFromTT(Score score, int ply);
         static int PieceValue(NeraChessEngine::Piece piece);
@@ -144,6 +149,9 @@ namespace NeraChessSearch
         uint64_t m_Nodes = 0;
         uint64_t m_UnflushedNodes = 0;
         int m_SelectiveDepth = 0;
+        // Repetition-key stack size at the search root, recorded once per
+        // SearchWorker call. See IsInTreeRepetition.
+        std::size_t m_RootRepetitionPlies = 0;
 
         // One NNUE accumulator per ply, private to this worker, updated
         // incrementally as the search makes and unmakes moves.

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -243,6 +243,26 @@ namespace
         ChessBoard capturableNoEp("4k3/8/8/8/3pP3/8/8/4K3 b - - 0 1");
         Require(capturableEp.GetZobristKey() != capturableNoEp.GetZobristKey(),
             "capturable en passant was omitted from position identity");
+
+        // GetRepetitionPlies / RepeatsWithin are the primitives the search uses to
+        // detect an in-tree twofold before a game-rule threefold (see issue #18).
+        ChessBoard twofold;
+        Require(twofold.GetRepetitionPlies() == 1,
+            "a freshly constructed board did not record its own position");
+
+        twofold.MakeMove(FindMove(twofold, "g1f3"), true);
+        twofold.MakeMove(FindMove(twofold, "g8f6"), true);
+        twofold.MakeMove(FindMove(twofold, "f3g1"), true);
+        Require(!twofold.RepeatsWithin(2),
+            "RepeatsWithin fired before the cycle had actually repeated");
+
+        twofold.MakeMove(FindMove(twofold, "f6g8"), true);
+        Require(twofold.GetRepetitionPlies() == 5,
+            "GetRepetitionPlies did not track four moves on top of the starting position");
+        Require(twofold.RepeatsWithin(4),
+            "RepeatsWithin missed a position repeating exactly at its distance bound");
+        Require(!twofold.RepeatsWithin(2),
+            "RepeatsWithin found a repetition outside the distance it was given");
     }
 
     void TestIncrementalZobrist()
@@ -1798,6 +1818,41 @@ namespace
         const auto bestMove = search.Search(tactical, limits).bestMove;
         Require(bestMove == FindMove(tactical, "d5e6") || bestMove == FindMove(tactical, "e2a6"),
             "search missed both top tactical continuations in the benchmark");
+
+        // In-tree twofold repetition (issue #18). White is down a queen and two
+        // rooks with nothing but a perpetual check (Qe6+/Qh3+) to save the game.
+        // The game-rule draw test needs a genuine threefold -- the cycle walked
+        // twice -- to see this, so at a depth deep enough to find the perpetual
+        // but not yet a third occurrence, it still reported a large score for the
+        // side about to be perpetually checked. This fails on that older
+        // behavior (score 51) and passes once a position repeating once since the
+        // root is scored a draw immediately.
+        search.NewGame();
+        ChessBoard perpetual("rr3bk1/6p1/8/8/q7/3B4/4Q3/6K1 w - - 0 1");
+        SearchLimits perpetualLimits;
+        perpetualLimits.maxDepth = 12;
+        const SearchResult perpetualResult = search.Search(perpetual, perpetualLimits);
+        Require(perpetualResult.score == SCORE_DRAW,
+            "in-tree repetition of a forced perpetual was not scored as a draw");
+
+        // Same defect, conversion phase: a won Q+N vs R+R endgame whose reported
+        // principal variation cycles back to a position it has already passed
+        // through, which a correct search should never prefer over progress.
+        search.NewGame();
+        ChessBoard endgame("8/8/2n5/1k6/1p2q3/8/1R5K/1R6 b - - 7 55");
+        SearchLimits endgameLimits;
+        endgameLimits.maxDepth = 13;
+        const SearchResult endgameResult = search.Search(endgame, endgameLimits);
+        std::vector<uint64_t> pvKeys{ endgame.GetZobristKey() };
+        ChessBoard pvWalker = endgame;
+        for (const NeraChessEngine::Move pvMove : endgameResult.principalVariation)
+        {
+            pvWalker.MakeMove(pvMove, true);
+            const uint64_t key = pvWalker.GetZobristKey();
+            Require(std::find(pvKeys.begin(), pvKeys.end(), key) == pvKeys.end(),
+                "principal variation of a won endgame repeated a position it had already passed through");
+            pvKeys.push_back(key);
+        }
     }
 
     // Writes a network of deterministic pseudo-random weights.


### PR DESCRIPTION
## Summary

The search's only draw test was `ChessBoard::GetGameOver`'s game-rule threefold, which needs a repeating cycle walked *twice* before scoring it a draw. This adds an in-tree twofold test: a position that has already occurred once since the search root is scored a draw immediately, without waiting for a third occurrence.

## Problem

Closes #18.

`SearchEngine::PrincipalVariationSearch`/`QuiescenceSearch` called `ChessBoard::IsRuleDraw()`, which only recognizes a draw at a genuine threefold repetition (`RepetitionTable::GetRepetitionCount(...) >= 3`). That is the correct rule for the actual game, but the wrong rule for a search tree, where the standard is to treat the *first* repetition since the root as a draw. As a result the engine reported large winning scores for principal variations that repeat a position it had already visited — the mechanism by which a won endgame gets shuffled toward a draw, and by which perpetual checks (in either direction) go undetected for twice as many plies as necessary.

## Implementation

- `RepetitionTable::Size()` exposes the key-stack length.
- `ChessBoard::GetRepetitionPlies()` / `ChessBoard::RepeatsWithin(distance)` are new public accessors: the former is the repetition-key stack size, the latter reports whether the current position has occurred at least once more within `distance` plies (same side to move), counting itself.
- `SearchEngine::IsInTreeRepetition(board, ply)` records the repetition-key stack size at the search root (`m_RootRepetitionPlies`, set once per `SearchWorker` call) and, at every node past the root, checks whether the current position repeats something already seen since the root. It's called ahead of the existing `board.IsRuleDraw()` check in both `PrincipalVariationSearch` and `QuiescenceSearch`.
- Distance to root is measured off the repetition-key stack rather than the search `ply` counter, because `ChessBoard::MakeNullMove` pushes no repetition key — using `ply` would read past the root after a null move.
- The root's own repetition is deliberately excluded (Stockfish's rule, `repetition < ply`): repeating the root once still needs an ordinary threefold, matching the "aggressive variant" the issue calls out as worth keeping separate.
- Because the in-tree check runs before the TT probe (same as the existing `IsRuleDraw` check), a repetition node never stores its path-dependent draw score into the shared transposition table.

## Why this approach

The issue's own prototype was followed directly: a `pliesSinceRoot - 1` bound with a `>= 2` occurrence threshold, using the repetition-key stack (not `ply`) to stay correct across null moves. The alternative of changing `ChessBoard::GetGameOver`'s game rule was rejected, as it must — the actual game-over reporting used by UCI/the desktop app still needs a genuine threefold.

## Validation

```
Release regression suite (no NNUE):      PASS
Release regression suite (--eval-file):  PASS
Debug regression suite (--eval-file):    PASS  (accumulator full-refresh asserts active)
UCI pondering smoke test:                PASS
```

Two new regression tests were added to `NeraChessTests/src/main.cpp`, both confirmed to fail against the pre-fix code and pass against the fix (checked directly at the `SearchEngine` API level, `SearchEngine(32)` + `NewGame()`, matching the harness the tests use):

- A forced-perpetual position (`rr3bk1/6p1/8/8/q7/3B4/4Q3/6K1 w - - 0 1`) at `maxDepth=12`: old code scores `+51` (not yet a real threefold), new code scores `0`.
- The endgame position from the issue (`8/8/2n5/1k6/1p2q3/8/1R5K/1R6 b - - 7 55`) at `maxDepth=13`: the reported principal variation is walked and asserted to contain no repeated position (by Zobrist key). The old PV visibly cycles (`e4h7 h2g1 h7g6 g1h1 g6h7 h1g1 ...`, scored `+793`); the new PV does not (`e4e5 h2h1 e5e4 h1g1 e4f5 ...`, scored `+765`).

A lower-level unit test also exercises `GetRepetitionPlies`/`RepeatsWithin` directly against a simple four-ply knight-shuffle cycle.

**Node cost.** Fixed-depth (`maxDepth=12`, 32 MiB hash) node counts across a 7-position sample (opening, two middlegames, a rook endgame, and the three issue positions), measured directly through the `SearchEngine` API on both revisions:

| | total nodes |
|---|---:|
| baseline | 1,633,680 |
| candidate | 1,932,991 |
| change | **+18.3%** |

This matches the issue's own measurement (+19.6% on its sample) and is concentrated in the positions that actually contain a near-term repetition; the plain opening/middlegame positions in the sample were within ±6%.

## Strength test

1,000-game screening match at `10+0.1`, candidate vs `main`, via the repository's `Strength test` GitHub Actions workflow.

```
Candidate: c5748434826b45ad3571eeb0a3ee471e559a0501
Baseline:  6df344df4a659adb85b50a16654879d911c66720
Games: 1000
Time control: 10+0.1
W/D/L: 271 / 501 / 228
Candidate score: 52.15%
Estimated Elo: +14.9
Approximate paired 95% interval: [+0.8, +29.1]
Pentanomial: [24, 100, 208, 145, 23]
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/33040082606
```

The interval excludes zero on the positive side, but this is a single 1,000-game screening result, not proof of the exact Elo figure — small differences remain noisy at this sample size.

## Risks

- The node-cost increase (+18%) is real and, per the issue, is expected to run roughly half a ply behind baseline at fixed time in the affected positions; the strength test above is at a fixed time control (`10+0.1`) and already reflects that cost.
- Repetition draws are path-dependent. A repetition node's *parent* still stores its own score in the shared TT under its own key, which can be reused on a different path where the repetition doesn't apply — this is inherent to the technique, and the mitigation (not storing anything at the repetition node itself) is already in place by returning before the TT probe.
- With `Threads > 1`, the shared TT spreads those path-dependent scores between workers, same as before.
- No contempt is implemented today, so the draw score is exactly 0; if contempt is added later it will need to apply at this return too.

---
_Generated by [Claude Code](https://claude.ai/code/session_014qn87RVmApTVhqP67xeKHG)_