### PR TITLE
Play strength tests until the result is decisive

### DIFF
--- a/.github/actions/strength-decision/action.yml
+++ b/.github/actions/strength-decision/action.yml
@@ -1,0 +1,65 @@
+name: Strength decision
+description: >
+  Combine every shard played so far and decide whether another stage is worth
+  running.
+
+inputs:
+  mode:
+    description: sequential or fixed
+    required: true
+  target_games:
+    description: Total games planned for the test
+    required: true
+  elo1:
+    description: Elo improvement the test is powered to detect
+    required: true
+  stage:
+    description: Stage that has just finished
+    required: true
+
+outputs:
+  continue:
+    description: true when another stage should be played
+    value: ${{ steps.summarize.outputs.continue }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download every shard played so far
+      uses: actions/download-artifact@v7
+      with:
+        pattern: strength-shard-*
+        path: ${{ runner.temp }}/nerachess-strength-shards
+
+    - name: Apply the stopping rule
+      id: summarize
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        ELO1: ${{ inputs.elo1 }}
+        TARGET_GAMES: ${{ inputs.target_games }}
+      run: |
+        set -euo pipefail
+
+        python3 scripts/strength/Summarize-Results.py \
+          "$RUNNER_TEMP/nerachess-strength-shards" \
+          --mode "$MODE" \
+          --elo1 "$ELO1" \
+          --target-games "$TARGET_GAMES" \
+          --output "$RUNNER_TEMP/strength-summary.md" \
+          --decision-output "$RUNNER_TEMP/strength-decision.txt"
+
+        cat "$RUNNER_TEMP/strength-decision.txt" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### After stage ${{ inputs.stage }}"
+          echo
+          cat "$RUNNER_TEMP/strength-summary.md"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload running summary
+      uses: actions/upload-artifact@v7
+      with:
+        name: strength-summary-after-stage-${{ inputs.stage }}
+        path: ${{ runner.temp }}/strength-summary.md
+        retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,11 @@ jobs:
           cd NNUETraining
           python3 -m unittest discover -s tests -t .
 
+      - name: Run strength test statistics tests
+        run: |
+          python3 -m unittest discover \
+            -s scripts/strength/tests -t scripts/strength/tests
+
       - name: Verify the engine and trainer agree on a network
         run: |
           cd NNUETraining

--- a/.github/workflows/strength-stage.yml
+++ b/.github/workflows/strength-stage.yml
@@ -1,0 +1,107 @@
+name: Strength stage
+
+# One stage of a strength test: four shards playing the same number of opening
+# pairs in parallel, each with its own opening seed. The calling workflow runs
+# these one after another and decides between them whether to keep going.
+
+on:
+  workflow_call:
+    inputs:
+      candidate_sha:
+        required: true
+        type: string
+      baseline_sha:
+        required: true
+        type: string
+      time_control:
+        required: true
+        type: string
+      allow_network_change:
+        required: true
+        type: boolean
+      stage:
+        description: Stage number, used to name artifacts and pick seeds
+        required: true
+        type: number
+      pairs:
+        description: Opening pairs each shard plays in this stage
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  match:
+    name: Stage ${{ inputs.stage }} shard ${{ matrix.shard }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    env:
+      STRENGTH_TC: ${{ inputs.time_control }}
+      STRENGTH_CONCURRENCY: "2"
+      STRENGTH_MAX_PAIRS: ${{ inputs.pairs }}
+      STRENGTH_HASH_MB: "128"
+      STRENGTH_THREADS: "1"
+      STRENGTH_STAGE: ${{ inputs.stage }}
+      STRENGTH_SHARD: ${{ matrix.shard }}
+      ALLOW_NETWORK_CHANGE: ${{ inputs.allow_network_change }}
+
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Choose the opening seed
+        run: |
+          # Every stage draws a fresh block of seeds, so no stage replays the
+          # openings another stage has already played.
+          echo "STRENGTH_SEED=$((1000 * STRENGTH_STAGE + STRENGTH_SHARD))" \
+            >> "$GITHUB_ENV"
+
+      - name: Prepare Fastchess and openings
+        run: |
+          bash scripts/strength/Prepare-Tools.sh "$RUNNER_TEMP/nerachess-strength-tools"
+          echo "FASTCHESS_BIN=$RUNNER_TEMP/nerachess-strength-tools/bin/fastchess" >> "$GITHUB_ENV"
+          echo "OPENING_BOOK=$RUNNER_TEMP/nerachess-strength-tools/books/UHO_4060_v4.epd" >> "$GITHUB_ENV"
+
+      - name: Create isolated source trees
+        run: |
+          git worktree add --detach "$RUNNER_TEMP/nerachess-candidate-source" \
+            "${{ inputs.candidate_sha }}"
+          git worktree add --detach "$RUNNER_TEMP/nerachess-baseline-source" \
+            "${{ inputs.baseline_sha }}"
+
+      - name: Build candidate
+        run: |
+          bash scripts/strength/Build-Engine.sh \
+            "$RUNNER_TEMP/nerachess-candidate-source" \
+            "$RUNNER_TEMP/nerachess-candidate-build"
+
+      - name: Build baseline
+        run: |
+          bash scripts/strength/Build-Engine.sh \
+            "$RUNNER_TEMP/nerachess-baseline-source" \
+            "$RUNNER_TEMP/nerachess-baseline-build"
+
+      - name: Play ${{ inputs.pairs }} opening pairs
+        run: |
+          bash scripts/strength/Run-Match.sh \
+            "$RUNNER_TEMP/nerachess-candidate-build" \
+            "$RUNNER_TEMP/nerachess-baseline-build" \
+            "$OPENING_BOOK" \
+            "$RUNNER_TEMP/nerachess-strength-results"
+
+      - name: Upload shard results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: strength-shard-${{ inputs.stage }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/nerachess-strength-results
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/strength-test.yml
+++ b/.github/workflows/strength-test.yml
@@ -17,6 +17,25 @@ on:
         required: true
         default: 10+0.1
         type: string
+      games:
+        description: >-
+          Fixed number of games to play. Leave at 0 to play until the result is
+          decisive instead.
+        required: true
+        default: "0"
+        type: string
+      max_games:
+        description: >-
+          Ceiling on a decisive test. Reached without a decision, the test
+          reports as inconclusive.
+        required: true
+        default: "12000"
+        type: string
+      elo1:
+        description: Elo improvement the test is powered to detect
+        required: true
+        default: "5"
+        type: string
       allow_network_change:
         description: Allow candidate and baseline to use different NNUE files
         required: true
@@ -25,6 +44,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: nerachess-strength
@@ -32,11 +52,20 @@ concurrency:
 
 jobs:
   prepare:
-    name: Resolve revisions
+    name: Resolve revisions and plan stages
     runs-on: ubuntu-24.04
     outputs:
       candidate_sha: ${{ steps.revisions.outputs.candidate_sha }}
       baseline_sha: ${{ steps.revisions.outputs.baseline_sha }}
+      mode: ${{ steps.plan.outputs.mode }}
+      total_games: ${{ steps.plan.outputs.total_games }}
+      pairs_1: ${{ steps.plan.outputs.pairs_1 }}
+      pairs_2: ${{ steps.plan.outputs.pairs_2 }}
+      pairs_3: ${{ steps.plan.outputs.pairs_3 }}
+      pairs_4: ${{ steps.plan.outputs.pairs_4 }}
+      pairs_5: ${{ steps.plan.outputs.pairs_5 }}
+      pairs_6: ${{ steps.plan.outputs.pairs_6 }}
+      pairs_7: ${{ steps.plan.outputs.pairs_7 }}
 
     steps:
       - name: Check out test harness
@@ -79,103 +108,320 @@ jobs:
           echo "Candidate: $candidate_sha"
           echo "Baseline:  $baseline_sha"
 
-  match:
-    name: Match shard ${{ matrix.shard }}
+      - name: Plan the stages
+        id: plan
+        env:
+          GAMES: ${{ inputs.games }}
+          MAX_GAMES: ${{ inputs.max_games }}
+          ELO1: ${{ inputs.elo1 }}
+        run: |
+          set -euo pipefail
+
+          non_negative_integer='^(0|[1-9][0-9]*)$'
+          positive_number='^[0-9]+([.][0-9]+)?$'
+          if [[ ! "$GAMES" =~ $non_negative_integer ]]; then
+            echo "games must be a whole number, not '$GAMES'." >&2
+            exit 1
+          fi
+          if [[ ! "$MAX_GAMES" =~ $non_negative_integer ]]; then
+            echo "max_games must be a whole number, not '$MAX_GAMES'." >&2
+            exit 1
+          fi
+          if [[ ! "$ELO1" =~ $positive_number ]]; then
+            echo "elo1 must be a positive number, not '$ELO1'." >&2
+            exit 1
+          fi
+
+          if [[ "$GAMES" -gt 0 ]]; then
+            mode=fixed
+            target="$GAMES"
+          else
+            mode=sequential
+            target="$MAX_GAMES"
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+          python3 scripts/strength/Plan-Stages.py \
+            --games "$target" --output "$GITHUB_OUTPUT"
+
+  stage_1:
+    name: Stage 1
     needs: prepare
+    if: ${{ needs.prepare.outputs.pairs_1 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 1
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_1) }}
+
+  decide_1:
+    name: Decide after stage 1
+    needs: [prepare, stage_1]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_1.result != 'skipped' && needs.stage_1.result != 'cancelled' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 350
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard: 1
-            seed: 1001
-          - shard: 2
-            seed: 1002
-          - shard: 3
-            seed: 1003
-          - shard: 4
-            seed: 1004
-
-    env:
-      STRENGTH_TC: ${{ inputs.time_control }}
-      STRENGTH_CONCURRENCY: "2"
-      STRENGTH_MAX_PAIRS: "125"
-      STRENGTH_HASH_MB: "128"
-      STRENGTH_THREADS: "1"
-      STRENGTH_SEED: ${{ matrix.seed }}
-      ALLOW_NETWORK_CHANGE: ${{ inputs.allow_network_change }}
-
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
     steps:
       - name: Check out test harness
         uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
         with:
-          fetch-depth: 0
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 1
 
-      - name: Prepare Fastchess and openings
-        run: |
-          bash scripts/strength/Prepare-Tools.sh "$RUNNER_TEMP/nerachess-strength-tools"
-          echo "FASTCHESS_BIN=$RUNNER_TEMP/nerachess-strength-tools/bin/fastchess" >> "$GITHUB_ENV"
-          echo "OPENING_BOOK=$RUNNER_TEMP/nerachess-strength-tools/books/UHO_4060_v4.epd" >> "$GITHUB_ENV"
+  stage_2:
+    name: Stage 2
+    needs: [prepare, decide_1]
+    if: ${{ needs.decide_1.outputs.continue == 'true' && needs.prepare.outputs.pairs_2 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 2
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_2) }}
 
-      - name: Create isolated source trees
-        run: |
-          git worktree add --detach "$RUNNER_TEMP/nerachess-candidate-source" \
-            "${{ needs.prepare.outputs.candidate_sha }}"
-          git worktree add --detach "$RUNNER_TEMP/nerachess-baseline-source" \
-            "${{ needs.prepare.outputs.baseline_sha }}"
+  decide_2:
+    name: Decide after stage 2
+    needs: [prepare, stage_2]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_2.result != 'skipped' && needs.stage_2.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
 
-      - name: Build candidate
-        run: |
-          bash scripts/strength/Build-Engine.sh \
-            "$RUNNER_TEMP/nerachess-candidate-source" \
-            "$RUNNER_TEMP/nerachess-candidate-build"
-
-      - name: Build baseline
-        run: |
-          bash scripts/strength/Build-Engine.sh \
-            "$RUNNER_TEMP/nerachess-baseline-source" \
-            "$RUNNER_TEMP/nerachess-baseline-build"
-
-      - name: Play 250 games
-        run: |
-          bash scripts/strength/Run-Match.sh \
-            "$RUNNER_TEMP/nerachess-candidate-build" \
-            "$RUNNER_TEMP/nerachess-baseline-build" \
-            "$OPENING_BOOK" \
-            "$RUNNER_TEMP/nerachess-strength-results"
-
-      - name: Upload shard results
-        if: always()
-        uses: actions/upload-artifact@v7
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
         with:
-          name: strength-shard-${{ matrix.shard }}
-          path: ${{ runner.temp }}/nerachess-strength-results
-          if-no-files-found: error
-          retention-days: 30
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 2
+
+  stage_3:
+    name: Stage 3
+    needs: [prepare, decide_2]
+    if: ${{ needs.decide_2.outputs.continue == 'true' && needs.prepare.outputs.pairs_3 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 3
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_3) }}
+
+  decide_3:
+    name: Decide after stage 3
+    needs: [prepare, stage_3]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_3.result != 'skipped' && needs.stage_3.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
+        with:
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 3
+
+  stage_4:
+    name: Stage 4
+    needs: [prepare, decide_3]
+    if: ${{ needs.decide_3.outputs.continue == 'true' && needs.prepare.outputs.pairs_4 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 4
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_4) }}
+
+  decide_4:
+    name: Decide after stage 4
+    needs: [prepare, stage_4]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_4.result != 'skipped' && needs.stage_4.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
+        with:
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 4
+
+  stage_5:
+    name: Stage 5
+    needs: [prepare, decide_4]
+    if: ${{ needs.decide_4.outputs.continue == 'true' && needs.prepare.outputs.pairs_5 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 5
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_5) }}
+
+  decide_5:
+    name: Decide after stage 5
+    needs: [prepare, stage_5]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_5.result != 'skipped' && needs.stage_5.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
+        with:
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 5
+
+  stage_6:
+    name: Stage 6
+    needs: [prepare, decide_5]
+    if: ${{ needs.decide_5.outputs.continue == 'true' && needs.prepare.outputs.pairs_6 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 6
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_6) }}
+
+  decide_6:
+    name: Decide after stage 6
+    needs: [prepare, stage_6]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_6.result != 'skipped' && needs.stage_6.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
+        with:
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 6
+
+  stage_7:
+    name: Stage 7
+    needs: [prepare, decide_6]
+    if: ${{ needs.decide_6.outputs.continue == 'true' && needs.prepare.outputs.pairs_7 != '0' }}
+    uses: ./.github/workflows/strength-stage.yml
+    with:
+      candidate_sha: ${{ needs.prepare.outputs.candidate_sha }}
+      baseline_sha: ${{ needs.prepare.outputs.baseline_sha }}
+      time_control: ${{ inputs.time_control }}
+      allow_network_change: ${{ inputs.allow_network_change }}
+      stage: 7
+      pairs: ${{ fromJSON(needs.prepare.outputs.pairs_7) }}
+
+  decide_7:
+    name: Decide after stage 7
+    needs: [prepare, stage_7]
+    # A shard whose runner dies loses its own games, not the whole test: decide
+    # on whatever did come back rather than throwing the earlier stages away.
+    if: ${{ always() && needs.stage_7.result != 'skipped' && needs.stage_7.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      continue: ${{ steps.decision.outputs.continue }}
+    steps:
+      - name: Check out test harness
+        uses: actions/checkout@v7
+
+      - name: Combine and decide
+        id: decision
+        uses: ./.github/actions/strength-decision
+        with:
+          mode: ${{ needs.prepare.outputs.mode }}
+          target_games: ${{ needs.prepare.outputs.total_games }}
+          elo1: ${{ inputs.elo1 }}
+          stage: 7
 
   summarize:
-    name: Combine 1,000 games
-    needs: [prepare, match]
-    if: ${{ always() && needs.match.result == 'success' }}
+    name: Final result
+    needs: [prepare, decide_1, decide_2, decide_3, decide_4, decide_5, decide_6, decide_7]
+    if: ${{ always() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-24.04
 
     steps:
       - name: Check out test harness
         uses: actions/checkout@v7
 
-      - name: Download shard results
+      - name: Download every shard
         uses: actions/download-artifact@v7
         with:
           pattern: strength-shard-*
           path: ${{ runner.temp }}/nerachess-strength-shards
 
-      - name: Calculate combined result
+      - name: Calculate the combined result
+        env:
+          MODE: ${{ needs.prepare.outputs.mode }}
+          ELO1: ${{ inputs.elo1 }}
+          TARGET_GAMES: ${{ needs.prepare.outputs.total_games }}
         run: |
           python3 scripts/strength/Summarize-Results.py \
             "$RUNNER_TEMP/nerachess-strength-shards" \
+            --mode "$MODE" \
+            --elo1 "$ELO1" \
+            --target-games "$TARGET_GAMES" \
             --output "$RUNNER_TEMP/strength-summary.md"
-          cat "$RUNNER_TEMP/strength-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Final result"
+            echo
+            cat "$RUNNER_TEMP/strength-summary.md"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload combined summary
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,11 @@ changes. Generation networks live under `NeraChessApp/Resources/NNUE/`, are
 loaded automatically by both the UCI engine and the desktop app at startup,
 and are read by the `EvalFile` UCI option.
 
-The bar for shipping a network is a match confidence interval that excludes
-zero, not merely a score above 50%.
+The bar for shipping a network is the strength test reaching
+**Accepted: improvement** — the sequential test in
+`.github/workflows/strength-test.yml` crossing its upper boundary — not merely a
+score above 50%, and not an interval that happens to clear zero. See
+`docs/Strength-Testing.md`.
 
 ## Notes specific to this repo
 

--- a/docs/Strength-Testing.md
+++ b/docs/Strength-Testing.md
@@ -1,26 +1,72 @@
 # NeraChess strength testing
 
 The manually triggered GitHub Actions workflow compares one exact NeraChess
-revision against another over 1,000 games. GitHub supplies temporary Ubuntu
-machines; no server or self-hosted runner is required.
+revision against another and plays until the answer is clear. GitHub supplies
+temporary Ubuntu machines; no server or self-hosted runner is required.
 
 ## Test design
 
-- Four GitHub-hosted jobs run in parallel.
-- Each job plays 125 opening pairs, or 250 games.
-- Every opening is played with colors reversed.
-- Each shard uses a different recorded opening seed.
+The test runs in **stages**. Each stage is four GitHub-hosted jobs playing in
+parallel; between stages the workflow combines everything played so far and
+decides whether another stage would tell it anything.
+
+- Every opening is played with colors reversed, and results are counted in
+  pairs rather than single games.
+- Each stage draws its own block of opening seeds, so no stage replays the
+  openings an earlier one already played.
 - Each engine gets one search thread and 128 MiB of hash.
 - NeraChess's internal opening book is disabled.
 - The external positions come from `UHO_4060_v4.epd`.
 - Candidate and baseline are compiled independently on each shard.
 - The bundled NNUE files must match unless a network change is intentional.
-- A final job combines the four Fastchess results into one estimated Elo and
-  approximate paired 95% interval.
+
+Stages get longer as the test goes on, so an obvious change is cheap and a
+small one still accumulates games at a reasonable rate:
+
+| Stage | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Games | 1,000 | 1,000 | 2,000 | 2,000 | 4,000 | 4,000 | 4,000 |
+| Roughly | 70 min | 70 min | 2.3 h | 2.3 h | 4.6 h | 4.6 h | 4.6 h |
 
 The Fastchess revision, opening download, and opening archive checksum are
 pinned in `scripts/strength/Prepare-Tools.sh`. PGNs, logs, configurations, and
 the combined summary are retained as workflow artifacts for 30 days.
+
+## The stopping rule
+
+"Keep playing until the confidence interval excludes zero" is not a rule a test
+can actually follow. If the two engines are genuinely equal the interval never
+excludes zero, so the test never ends; and an interval consulted over and over
+crosses zero eventually by chance alone, so a test that stops the first time it
+does would call far more than 5% of neutral changes an improvement.
+
+The workflow therefore runs a **sequential probability ratio test**, the same
+instrument Fishtest uses, which is the disciplined version of the same idea. It
+weighs two hypotheses:
+
+- **H0** — the change is worth 0 Elo or less.
+- **H1** — the change is worth at least `elo1`, 5 Elo by default.
+
+After each stage it computes the log likelihood ratio between them from the
+pentanomial pair counts and stops when that ratio passes either boundary,
+accepting one hypothesis or the other with a 5% error rate on each side. That
+error rate holds *despite* looking after every stage, which is exactly what an
+interval cannot promise.
+
+Roughly what this costs, by how large the change really is:
+
+| True strength change | Typical games to a verdict |
+|---|---:|
+| +65 Elo | 1,000 (one stage) |
+| +30 Elo | 1,000 (one stage) |
+| +12 Elo | ~3,600 |
+| 0 Elo | ~2,800, rejected |
+| +5 Elo | ~8,400, and genuinely ambiguous |
+
+A change worth exactly `elo1` sits on the boundary between the hypotheses and is
+the slowest case by design. A test that reaches `max_games` without a verdict
+reports as inconclusive, which is a real answer: the change is too small to
+measure at this time control.
 
 ## Running a test
 
@@ -36,22 +82,50 @@ the combined summary are retained as workflow artifacts for 30 days.
 The prepare job resolves both names to immutable commit hashes. A later change
 to either branch cannot alter a match that has already started.
 
+### Inputs
+
+| Input | Default | |
+|---|---|---|
+| `candidate_ref` | | Revision under test |
+| `baseline_ref` | `main` | Revision to beat |
+| `time_control` | `10+0.1` | Fastchess time control |
+| `games` | `0` | Play exactly this many games and skip the sequential test |
+| `max_games` | `12000` | Ceiling on a sequential test |
+| `elo1` | `5` | Improvement the test is powered to detect |
+| `allow_network_change` | `false` | Permit differing NNUE files |
+
+Set `games` to a number to get the old behaviour: a fixed-length test that plays
+everything asked of it and reports the estimate and interval without stopping
+early. `games=1000` reproduces exactly what the workflow used to do. This is the
+right choice when the point is to measure something rather than to decide it —
+comparing two networks, or putting a number on a change already known to help.
+
+Lower `elo1` to hunt for smaller gains, at a steep price in games: the cost of a
+sequential test rises roughly with the square of the effect it must resolve, so
+`elo1=2` is around six times the games of `elo1=5`.
+
+Raise `max_games` when a result matters enough to pay for it. The ceiling is
+18,000 games; beyond that, run at a longer time control instead, which buys more
+information per game than more games at 10+0.1.
+
 ## Reading the result
 
-The combined workflow summary reports one of these screening verdicts:
+Each stage appends a running summary to the workflow summary page, so a test in
+flight can be watched. The verdicts are:
 
-- **Likely improvement:** the approximate interval is entirely above zero.
-- **Promising, but inconclusive:** the estimate is at least +5 Elo, but the
-  interval still includes zero.
-- **No clear difference:** the estimate is between -5 and +5 Elo and its
-  interval includes zero.
-- **Concerning, but inconclusive:** the estimate is at most -5 Elo, but the
-  interval still includes zero.
-- **Likely regression:** the approximate interval is entirely below zero.
+- **Accepted: improvement** — H1 accepted. This clears the bar for merging.
+- **Rejected: not an improvement** — H0 accepted. The change is not worth
+  `elo1`; it may still be neutral rather than harmful.
+- **Undecided, playing on** — no boundary crossed yet; another stage follows.
+- **Inconclusive verdicts** (`Likely improvement`, `Promising, but
+  inconclusive`, `No clear difference`, and so on) — reported when a fixed
+  length test finishes or a sequential one hits `max_games`. These describe the
+  games played and carry no error guarantee.
 
-One thousand games are useful for screening obvious gains and regressions, but
-not for proving small changes. A promising result should receive a longer test
-before a marginal or risky search change is accepted.
+The estimate and interval are always reported, because they say *how large* a
+change is where the verdict only says whether it is real. Do not read the
+interval as a test in its own right: in a sequential run it has been consulted
+repeatedly and is narrower than it looks.
 
 ## Local use
 
@@ -70,7 +144,20 @@ bash scripts/strength/Run-Match.sh \
   /tmp/baseline-build \
   /tmp/strength-tools/books/UHO_4060_v4.epd \
   /tmp/strength-results
+
+python3 scripts/strength/Summarize-Results.py /tmp/strength-results
 ```
+
+Run more batches into sibling directories under one parent and point
+`Summarize-Results.py` at the parent; it combines every `fastchess.log` beneath
+whatever directory it is given. Use a different `STRENGTH_SEED` for each, or
+they will replay the same openings and the extra games will add no information.
 
 Use fresh output directories for every run so old binaries and PGNs cannot be
 mistaken for the current experiment.
+
+The statistics have their own tests:
+
+```bash
+python3 -m unittest discover -s scripts/strength/tests -t scripts/strength/tests
+```

--- a/scripts/strength/Plan-Stages.py
+++ b/scripts/strength/Plan-Stages.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+"""Divide a strength test into the stages the workflow plays one after another.
+
+Stages exist so a sequential test can stop early: the workflow plays one, asks
+Summarize-Results.py whether the answer is already clear, and only pays for the
+next one if it is not. Early stages are small so an obvious change resolves
+quickly; later ones are larger so a genuinely small change still accumulates
+games at a reasonable rate.
+"""
+
+import argparse
+from pathlib import Path
+
+
+SHARDS = 4
+GAMES_PER_PAIR = 2
+GAMES_PER_STAGE_UNIT = SHARDS * GAMES_PER_PAIR
+
+# Games per stage. A stage of 1,000 games takes about 70 minutes of wall clock;
+# the largest here is about 4.5 hours, which keeps every shard job clear of the
+# six-hour limit GitHub imposes on a hosted runner.
+STAGE_LADDER = (1000, 1000, 2000, 2000, 4000, 4000, 4000)
+MAX_TOTAL_GAMES = sum(STAGE_LADDER)
+
+
+def plan(total_games: int) -> list[int]:
+    """Return the games played in each stage, shortest schedule reaching the total."""
+    if total_games < GAMES_PER_STAGE_UNIT:
+        raise ValueError(
+            f"A test needs at least {GAMES_PER_STAGE_UNIT} games, not {total_games}."
+        )
+    if total_games > MAX_TOTAL_GAMES:
+        raise ValueError(
+            f"A test cannot exceed {MAX_TOTAL_GAMES} games, and {total_games} "
+            "was requested. Run a second test if more are genuinely needed."
+        )
+
+    stages = []
+    remaining = total_games
+    for stage_games in STAGE_LADDER:
+        if remaining <= 0:
+            break
+        stages.append(min(stage_games, remaining))
+        remaining -= stages[-1]
+    return stages
+
+
+def round_to_stage_unit(games: int) -> int:
+    """Round up so every shard plays a whole number of opening pairs."""
+    units = -(-games // GAMES_PER_STAGE_UNIT)
+    return units * GAMES_PER_STAGE_UNIT
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plan NeraChess strength test stages.")
+    parser.add_argument(
+        "--games",
+        type=int,
+        required=True,
+        help="Total games to plan for; a sequential test may stop before them.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="File to append key=value lines to, such as GITHUB_OUTPUT.",
+    )
+    args = parser.parse_args()
+
+    total_games = round_to_stage_unit(args.games)
+    try:
+        stages = plan(total_games)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+    lines = [f"total_games={total_games}", f"stage_count={len(stages)}"]
+    for index in range(len(STAGE_LADDER)):
+        stage_games = stages[index] if index < len(stages) else 0
+        pairs = stage_games // GAMES_PER_STAGE_UNIT
+        lines.append(f"pairs_{index + 1}={pairs}")
+
+    report = "\n".join(lines) + "\n"
+    print(report, end="")
+    if args.output:
+        with args.output.open("a", encoding="utf-8") as handle:
+            handle.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strength/Run-Match.sh
+++ b/scripts/strength/Run-Match.sh
@@ -27,6 +27,7 @@ max_pairs="${STRENGTH_MAX_PAIRS:-125}"
 hash_mb="${STRENGTH_HASH_MB:-128}"
 threads="${STRENGTH_THREADS:-1}"
 seed="${STRENGTH_SEED:-1}"
+stage="${STRENGTH_STAGE:-1}"
 allow_network_change="${ALLOW_NETWORK_CHANGE:-false}"
 
 candidate="${candidate_directory}/NeraChessUCI"
@@ -57,7 +58,8 @@ for name_and_value in \
   "max pairs:${max_pairs}" \
   "hash size:${hash_mb}" \
   "threads:${threads}" \
-  "seed:${seed}"; do
+  "seed:${seed}" \
+  "stage:${stage}"; do
   name="${name_and_value%%:*}"
   value="${name_and_value#*:}"
   if [[ ! "${value}" =~ ${positive_integer} ]]; then
@@ -110,7 +112,7 @@ results_directory="$(realpath "${results_directory}")"
   echo "max_pairs=${max_pairs}"
   echo "threads=${threads}"
   echo "hash_mb=${hash_mb}"
-  echo "test=fixed_games"
+  echo "stage=${stage}"
   echo "opening_seed=${seed}"
   "${fastchess_bin}" -version 2>&1 | sed 's/^/fastchess=/'
 } | tee "${results_directory}/configuration.txt"

--- a/scripts/strength/Summarize-Results.py
+++ b/scripts/strength/Summarize-Results.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 
+"""Combine Fastchess shard results and apply the sequential stopping rule.
+
+The workflow plays games in stages and calls this script after each one, so the
+verdict here decides whether another stage is worth its hour of runner time.
+"""
+
 import argparse
+import json
 import math
 import re
 from pathlib import Path
@@ -13,10 +20,18 @@ PENTANOMIAL_PATTERN = re.compile(
     r"Ptnml\(0-2\): \[(\d+), (\d+), (\d+), (\d+), (\d+)\]"
 )
 
+# A pair contributes 0 to 2 game points; normalise to [0, 1] so the mean is
+# directly comparable with a per-game score.
+PAIR_SCORES = (0.0, 0.25, 0.5, 0.75, 1.0)
+
 
 def logistic_elo(score: float) -> float:
     score = min(max(score, 1e-9), 1.0 - 1e-9)
     return 400.0 * math.log10(score / (1.0 - score))
+
+
+def logistic_score(elo: float) -> float:
+    return 1.0 / (1.0 + 10.0 ** (-elo / 400.0))
 
 
 def parse_log(path: Path) -> tuple[int, int, int, list[int]]:
@@ -37,12 +52,74 @@ def parse_log(path: Path) -> tuple[int, int, int, list[int]]:
     return wins, losses, draws, penta
 
 
+def pair_statistics(penta: list[int]) -> tuple[int, float, float]:
+    """Return the pair count, mean normalised pair score, and its variance."""
+    pairs = sum(penta)
+    if pairs == 0:
+        return 0, 0.0, 0.0
+
+    mean = sum(
+        count * value for count, value in zip(penta, PAIR_SCORES)
+    ) / pairs
+    if pairs > 1:
+        variance = sum(
+            count * (value - mean) ** 2
+            for count, value in zip(penta, PAIR_SCORES)
+        ) / (pairs - 1)
+    else:
+        variance = 0.0
+    return pairs, mean, variance
+
+
+def log_likelihood_ratio(
+    pairs: int, mean: float, variance: float, elo0: float, elo1: float
+) -> float:
+    """Normal-approximation LLR for H0: Elo = elo0 against H1: Elo = elo1.
+
+    Each opening pair is one observation. Treating the pair score as normal with
+    the observed variance, the log likelihood ratio has a closed form; this is
+    the standard approximation used for pentanomial SPRT in engine testing.
+    """
+    if pairs < 2 or variance <= 0.0:
+        return 0.0
+
+    score0 = logistic_score(elo0)
+    score1 = logistic_score(elo1)
+    return (
+        pairs
+        * (score1 - score0)
+        * (2.0 * mean - score0 - score1)
+        / (2.0 * variance)
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Combine NeraChess Fastchess shard results."
     )
     parser.add_argument("results", type=Path)
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--decision-output",
+        type=Path,
+        help="Write continue=true/false and the verdict as key=value lines.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("sequential", "fixed"),
+        default="sequential",
+        help="sequential stops as soon as the test is decisive; fixed never does.",
+    )
+    parser.add_argument("--elo0", type=float, default=0.0)
+    parser.add_argument("--elo1", type=float, default=5.0)
+    parser.add_argument("--alpha", type=float, default=0.05)
+    parser.add_argument("--beta", type=float, default=0.05)
+    parser.add_argument(
+        "--target-games",
+        type=int,
+        default=0,
+        help="Total games planned; the test stops once they have been played.",
+    )
     args = parser.parse_args()
 
     logs = sorted(args.results.glob("**/fastchess.log"))
@@ -59,20 +136,12 @@ def main() -> None:
         penta = [left + right for left, right in zip(penta, shard_penta)]
 
     games = wins + losses + draws
-    pairs = sum(penta)
+    pairs, mean_pair_score, pair_variance = pair_statistics(penta)
     score = (wins + 0.5 * draws) / games
     elo = logistic_elo(score)
 
-    pair_scores = (0.0, 0.5, 1.0, 1.5, 2.0)
-    mean_pair_score = sum(
-        count * value for count, value in zip(penta, pair_scores)
-    ) / pairs
     if pairs > 1:
-        pair_variance = sum(
-            count * (value - mean_pair_score) ** 2
-            for count, value in zip(penta, pair_scores)
-        ) / (pairs - 1)
-        score_standard_error = math.sqrt(pair_variance / pairs) / 2.0
+        score_standard_error = math.sqrt(pair_variance / pairs)
     else:
         score_standard_error = 0.0
 
@@ -81,18 +150,54 @@ def main() -> None:
     low_elo = logistic_elo(low_score)
     high_elo = logistic_elo(high_score)
 
+    llr = log_likelihood_ratio(
+        pairs, mean_pair_score, pair_variance, args.elo0, args.elo1
+    )
+    upper_bound = math.log((1.0 - args.beta) / args.alpha)
+    lower_bound = math.log(args.beta / (1.0 - args.alpha))
+
+    exhausted = args.target_games > 0 and games >= args.target_games
+
+    if args.mode == "fixed":
+        accepted = None
+        keep_playing = not exhausted
+    elif llr >= upper_bound:
+        accepted = "H1"
+        keep_playing = False
+    elif llr <= lower_bound:
+        accepted = "H0"
+        keep_playing = False
+    else:
+        accepted = None
+        keep_playing = not exhausted
+
     if pairs < 50:
         verdict = "Insufficient games"
-    elif low_elo > 0:
-        verdict = "Likely improvement"
-    elif high_elo < 0:
-        verdict = "Likely regression"
-    elif elo >= 5:
-        verdict = "Promising, but inconclusive"
-    elif elo <= -5:
-        verdict = "Concerning, but inconclusive"
+    elif accepted == "H1":
+        verdict = "Accepted: improvement"
+    elif accepted == "H0":
+        verdict = "Rejected: not an improvement"
+    elif args.mode == "fixed" or exhausted:
+        if low_elo > 0:
+            verdict = "Likely improvement"
+        elif high_elo < 0:
+            verdict = "Likely regression"
+        elif elo >= 5:
+            verdict = "Promising, but inconclusive"
+        elif elo <= -5:
+            verdict = "Concerning, but inconclusive"
+        else:
+            verdict = "No clear difference"
     else:
-        verdict = "No clear difference"
+        verdict = "Undecided, playing on"
+
+    if args.mode == "fixed":
+        rule = f"Fixed length, {args.target_games} games, no early stopping"
+    else:
+        rule = (
+            f"SPRT H0: Elo <= {args.elo0:g} against H1: Elo >= {args.elo1:g}, "
+            f"alpha = {args.alpha:g}, beta = {args.beta:g}"
+        )
 
     summary = f"""## NeraChess strength result
 
@@ -110,13 +215,33 @@ def main() -> None:
 | Pentanomial | {penta} |
 | Completed shards | {len(logs)} |
 
-The interval is an approximate screening result, not proof of a small Elo
-change. Use a longer test before accepting a marginal search change.
+Stopping rule: {rule}.
+Log likelihood ratio {llr:+.2f}, stopping at {lower_bound:+.2f} or \
+{upper_bound:+.2f}.
+
+The interval is a descriptive summary of the games played. Because a sequential
+test looks at the data repeatedly, only the accept and reject verdicts above
+carry the stated error rates; the interval on its own does not.
 """
 
     print(summary, end="")
     if args.output:
         args.output.write_text(summary, encoding="utf-8")
+
+    if args.decision_output:
+        decision = {
+            "continue": "true" if keep_playing else "false",
+            "verdict": verdict,
+            "games": games,
+            "llr": f"{llr:.4f}",
+            "elo": f"{elo:.2f}",
+            "accepted": accepted or "none",
+        }
+        args.decision_output.write_text(
+            "".join(f"{key}={value}\n" for key, value in decision.items()),
+            encoding="utf-8",
+        )
+        print(json.dumps(decision))
 
 
 if __name__ == "__main__":

--- a/scripts/strength/tests/test_strength_statistics.py
+++ b/scripts/strength/tests/test_strength_statistics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+"""Tests for the strength test's stopping rule.
+
+These decide whether a change is merged, so the arithmetic behind them is worth
+pinning down. Run with:
+
+    python3 -m unittest discover -s scripts/strength/tests -t .
+"""
+
+import importlib.util
+import math
+import sys
+import unittest
+from pathlib import Path
+
+
+def load(name: str):
+    path = Path(__file__).resolve().parents[1] / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+summarize = load("Summarize-Results")
+planner = load("Plan-Stages")
+
+
+class EloConversion(unittest.TestCase):
+    def test_even_score_is_zero_elo(self):
+        self.assertAlmostEqual(summarize.logistic_elo(0.5), 0.0)
+        self.assertAlmostEqual(summarize.logistic_score(0.0), 0.5)
+
+    def test_conversions_are_inverses(self):
+        for elo in (-400.0, -5.0, 0.0, 5.0, 65.0, 400.0):
+            round_trip = summarize.logistic_elo(summarize.logistic_score(elo))
+            self.assertAlmostEqual(round_trip, elo, places=9)
+
+
+class PairStatistics(unittest.TestCase):
+    def test_reproduces_a_recorded_result(self):
+        # The AVX2 accumulator test on this repository: 1,000 games scoring
+        # 51.80%, reported as +12.5 Elo with an interval of [-0.3, +25.3].
+        penta = [14, 100, 239, 130, 17]
+        pairs, mean, variance = summarize.pair_statistics(penta)
+        self.assertEqual(pairs, 500)
+        self.assertAlmostEqual(mean, 0.518)
+
+        elo = summarize.logistic_elo(mean)
+        standard_error = math.sqrt(variance / pairs)
+        low = summarize.logistic_elo(mean - 1.96 * standard_error)
+        high = summarize.logistic_elo(mean + 1.96 * standard_error)
+        self.assertAlmostEqual(elo, 12.5, places=1)
+        self.assertAlmostEqual(low, -0.3, places=1)
+        self.assertAlmostEqual(high, 25.3, places=1)
+
+    def test_a_pair_score_matches_the_game_score(self):
+        # A symmetric spread of pairs is an even score however it is spread.
+        pairs, mean, _ = summarize.pair_statistics([1, 1, 0, 1, 1])
+        self.assertEqual(pairs, 4)
+        self.assertAlmostEqual(mean, 0.5)
+
+    def test_no_pairs_is_not_an_error(self):
+        self.assertEqual(summarize.pair_statistics([0, 0, 0, 0, 0]), (0, 0.0, 0.0))
+
+
+class LogLikelihoodRatio(unittest.TestCase):
+    def elo_bounds(self, alpha=0.05, beta=0.05):
+        return math.log(beta / (1.0 - alpha)), math.log((1.0 - beta) / alpha)
+
+    def test_an_even_result_moves_towards_rejection(self):
+        penta = [10, 100, 280, 100, 10]
+        pairs, mean, variance = summarize.pair_statistics(penta)
+        self.assertAlmostEqual(mean, 0.5)
+        llr = summarize.log_likelihood_ratio(pairs, mean, variance, 0.0, 5.0)
+        self.assertLess(llr, 0.0)
+
+    def test_a_large_gain_accepts_the_alternative(self):
+        # A lopsided result should clear the upper bound well inside one stage.
+        penta = [0, 10, 100, 240, 150]
+        pairs, mean, variance = summarize.pair_statistics(penta)
+        llr = summarize.log_likelihood_ratio(pairs, mean, variance, 0.0, 5.0)
+        _, upper = self.elo_bounds()
+        self.assertGreater(llr, upper)
+
+    def test_the_ratio_grows_with_the_number_of_pairs(self):
+        single = [14, 100, 239, 130, 17]
+        doubled = [2 * count for count in single]
+        one = summarize.log_likelihood_ratio(*summarize.pair_statistics(single), 0.0, 5.0)
+        two = summarize.log_likelihood_ratio(*summarize.pair_statistics(doubled), 0.0, 5.0)
+        self.assertGreater(two, 1.9 * one)
+
+    def test_too_few_pairs_decide_nothing(self):
+        self.assertEqual(summarize.log_likelihood_ratio(1, 1.0, 0.0, 0.0, 5.0), 0.0)
+
+    def test_an_identical_engine_never_divides_by_zero(self):
+        # Every pair drawn: no variance at all.
+        pairs, mean, variance = summarize.pair_statistics([0, 0, 500, 0, 0])
+        self.assertEqual(variance, 0.0)
+        self.assertEqual(
+            summarize.log_likelihood_ratio(pairs, mean, variance, 0.0, 5.0), 0.0
+        )
+
+
+class StagePlanning(unittest.TestCase):
+    def test_stages_sum_to_the_requested_total(self):
+        for games in (1000, 2000, 4000, 12000, planner.MAX_TOTAL_GAMES):
+            self.assertEqual(sum(planner.plan(games)), games)
+
+    def test_a_short_test_uses_one_stage(self):
+        self.assertEqual(planner.plan(1000), [1000])
+
+    def test_every_stage_divides_into_whole_pairs_per_shard(self):
+        for stage_games in planner.plan(planner.MAX_TOTAL_GAMES):
+            self.assertEqual(stage_games % planner.GAMES_PER_STAGE_UNIT, 0)
+
+    def test_stages_grow_apart_from_a_truncated_last_one(self):
+        for games in (4000, 12000, planner.MAX_TOTAL_GAMES):
+            leading = planner.plan(games)[:-1]
+            self.assertEqual(leading, sorted(leading))
+
+    def test_the_first_stage_is_the_length_of_a_screening_test(self):
+        # A change large enough to see quickly should not have to wait for more
+        # than the thousand games the fixed-length test used to play.
+        self.assertEqual(planner.plan(planner.MAX_TOTAL_GAMES)[0], 1000)
+
+    def test_rounding_reaches_whole_pairs_per_shard(self):
+        self.assertEqual(planner.round_to_stage_unit(1), 8)
+        self.assertEqual(planner.round_to_stage_unit(1000), 1000)
+        self.assertEqual(planner.round_to_stage_unit(1001), 1008)
+
+    def test_an_impossible_request_is_refused(self):
+        with self.assertRaises(ValueError):
+            planner.plan(0)
+        with self.assertRaises(ValueError):
+            planner.plan(planner.MAX_TOTAL_GAMES + 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The strength test plays a fixed 1,000 games and reports an interval. That is enough to catch a large change and not enough to judge a small one — the two speedups merged this week (#19, #22) both landed on intervals that still touched zero:

| | Elo | 95% interval |
|---|---:|---|
| #19 AVX2 accumulator fusion | +12.5 | [-0.3, +25.3] |
| #22 quiescence make/unmake skip | +11.1 | [-3.0, +25.3] |

Both were merged on a mechanism argument rather than on the games. This makes the games able to answer.

## What changed

The test now runs in **stages**. Each stage is the same four-shard matrix as before; between stages the workflow combines everything played so far and stops as soon as the answer is clear.

`strength-test.yml` orchestrates; `strength-stage.yml` is a reusable workflow holding the matrix; `.github/actions/strength-decision` is the between-stages decision.

### The stopping rule

Literally "keep playing until the interval excludes zero" is not implementable. Against an equal opponent the interval never excludes zero, so the test never terminates; and an interval consulted repeatedly crosses zero by chance eventually, so stopping the first time it does would call far more than 5% of neutral changes improvements.

So the workflow runs an SPRT on the pentanomial pair counts — H0: Elo ≤ 0 against H1: Elo ≥ 5, α = β = 0.05 — which is the disciplined version of the same idea and keeps its error rate *despite* looking after every stage.

### Cost

Stages grow: 1,000 → 1,000 → 2,000 → 2,000 → 4,000 → 4,000 → 4,000. An obvious change costs exactly what it costs today; a marginal one keeps accumulating games.

| True change | Typical games to a verdict | Wall clock |
|---|---:|---|
| +65 Elo | 1,000 | ~70 min |
| +30 Elo | 1,000 | ~70 min |
| +12 Elo | ~3,600 | ~4.7 h |
| 0 Elo | ~2,800, rejected | ~3.5 h |
| +5 Elo | ~8,400, ambiguous by design | ~9 h |

Measured from run 33040082606: a shard plays 250 games in 65 minutes, so the 4-shard matrix produces ~900 games/hour. Default ceiling is 12,000 games ≈ 13.5 h worst case. The repository is public, so GitHub-hosted minutes are free; the real cost is that `concurrency: nerachess-strength` serialises tests, and a worst-case run holds that lock for the day.

### Keeping the old behaviour

New `games` input. Set it to a number for a fixed-length test that plays everything asked and never stops early — for when the point is to measure a change rather than decide it (comparing two networks, or quantifying something already known to help). `games=1000` reproduces the previous workflow exactly, verdict text included.

Also new: `max_games` (default 12000) and `elo1` (default 5).

## Verification

- The pentanomial summary reproduces #19's recorded result exactly — +12.5 Elo, [-0.3, +25.3] — from the same counts. The interval arithmetic is unchanged; it was rewritten in normalised units and gives bit-identical output.
- `games=1000 --mode fixed` on those counts still prints `Promising, but inconclusive`.
- 17 new tests in `scripts/strength/tests/`, wired into the Linux CI job: Elo conversions round-trip, the LLR is pinned at both boundaries, and the two degenerate inputs that would divide by zero (a single pair, and every pair drawn) return 0 rather than crashing.
- The numbers in the table above come from simulating the full stage machinery against pentanomial distributions tilted to each true Elo.
- All three workflow files and the composite action parse; the job graph was checked programmatically.

Two details worth flagging, both of which bit during development:

- GitHub expressions have no arithmetic, so the per-stage seed is computed in shell rather than as `1000 * inputs.stage + matrix.shard`.
- Job IDs use underscores: `needs.decide-1.result` parses as subtraction.

## Incidental fixes

- Every stage draws its own block of opening seeds. Seeds were previously hardcoded at 1001–1004, so every dispatch replayed the same 250 opening pairs; reruns of the same candidate were correlated rather than independent.
- A shard whose runner dies no longer discards the whole test — the decision runs on whatever came back.
- `CLAUDE.md`'s shipping bar now points at the SPRT verdict rather than at an interval excluding zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)