### PR TITLE
Rescale NNUE activation into int16 to cut the output layer's cost

### DIFF
--- a/NNUETraining/nnue_training/quantize.py
+++ b/NNUETraining/nnue_training/quantize.py
@@ -155,21 +155,19 @@ def activate(value: int) -> int:
 
     Reference implementation of ``Quantization::Activate``; used by
     :mod:`nnue_training.verify` to reproduce the engine's arithmetic exactly.
+    Rescaled back onto ``[0, QUANTIZATION_A]`` immediately (rather than once
+    at the end, in ``dequantize``) so the result fits int16, matching the
+    engine's output-layer kernels.
     """
     clipped = max(0, min(arch.QUANTIZATION_A, value))
     if arch.ACTIVATION == arch.Activation.SQUARED_CLIPPED_RELU:
-        return clipped * clipped
+        return (clipped * clipped) // arch.QUANTIZATION_A
     return clipped
 
 
 def dequantize(weighted_sum: int, output_bias: int) -> int:
     """Weighted sum of activations to centipawns, matching ``Dequantize``."""
-    activation_scale = (
-        arch.QUANTIZATION_A
-        if arch.ACTIVATION == arch.Activation.SQUARED_CLIPPED_RELU
-        else 1
-    )
-    normalized = _truncating_div(weighted_sum, activation_scale) + output_bias
+    normalized = weighted_sum + output_bias
     return _truncating_div(
         normalized * arch.EVAL_SCALE, arch.QUANTIZATION_A * arch.QUANTIZATION_B
     )

--- a/NeraChessNNUE/src/Quantization.h
+++ b/NeraChessNNUE/src/Quantization.h
@@ -19,35 +19,81 @@
 // the layer sum. Every parameter is an int16_t, so the exporter must reject a
 // network whose output bias exceeds roughly +-2.0 in float terms; trained
 // output biases sit near zero, so this has never been a real constraint.
+//
+// Squaring the clipped activation introduces a second factor of QuantizationA
+// on top of the accumulator's own scale. Activate divides that factor back
+// out immediately (rather than once at the end, in Dequantize) so its result
+// -- and therefore the output layer's per-term product -- fits int16/int32
+// instead of needing an int32/int64 intermediate. See docs/NNUE.md.
 
 namespace NeraChessNNUE::Quantization
 {
-    // Applies the hidden-layer activation to one quantized accumulator value
-    // and widens the result so the caller can accumulate without overflow.
+    // Applies the hidden-layer activation to one quantized accumulator value,
+    // rescaled back onto the accumulator's own [0, QuantizationA] range so the
+    // output layer's kernels can multiply it against a weight with a single
+    // int16 x int16 -> int32 widening multiply instead of promoting through
+    // int32 first.
     //
-    // Squared clipped ReLU: clamp(x, 0, QuantizationA)^2, which is the
-    // quantized form of clamp(x, 0, 1)^2 scaled by QuantizationA^2.
-    constexpr Accumulation Activate(int32_t value)
+    // Squared clipped ReLU: clamp(x, 0, QuantizationA)^2 / QuantizationA,
+    // the quantized form of clamp(x, 0, 1)^2. The square and the division by
+    // it are both kept at uint16_t width rather than widened to uint32_t --
+    // at QuantizationA <= 255 the square never exceeds 65025, so it fits
+    // uint16_t exactly, and keeping it that narrow is what lets a vectorizing
+    // compiler lower the whole thing to a 16-bit clamp, a 16-bit multiply
+    // (the high bits of the true product are provably zero, so the low-half
+    // result is exact) and a 16-bit reciprocal-multiply division, instead of
+    // promoting through a 32-bit multiply and a 32-bit division.
+    constexpr int32_t Activate(int32_t value)
     {
         const int32_t clipped = std::clamp(value, 0, Architecture::QuantizationA);
         if constexpr (Architecture::Activation == Architecture::ActivationKind::SquaredClippedReLU)
-            return static_cast<Accumulation>(clipped) * clipped;
+        {
+            const uint16_t narrowed = static_cast<uint16_t>(clipped);
+            const uint16_t square = static_cast<uint16_t>(narrowed * narrowed);
+            return static_cast<int32_t>(square / static_cast<uint16_t>(Architecture::QuantizationA));
+        }
         else
-            return static_cast<Accumulation>(clipped);
+        {
+            return clipped;
+        }
     }
 
-    // The extra factor the activation introduces on top of the accumulator's
-    // own QuantizationA scale. Squaring applies it twice; clipping once.
-    inline constexpr int32_t ActivationScale =
-        Architecture::Activation == Architecture::ActivationKind::SquaredClippedReLU
-            ? Architecture::QuantizationA
-            : 1;
+    static_assert(Architecture::Activation != Architecture::ActivationKind::SquaredClippedReLU ||
+        Architecture::QuantizationA <= 255,
+        "Activate narrows the squared value through uint16_t, so QuantizationA^2 must fit it");
+
+    // Largest magnitude a single ActivatedDotProduct term can reach: an
+    // activated value (bounded by QuantizationA, since Activate always
+    // returns a value in [0, QuantizationA]) times the largest magnitude an
+    // int16 weight can hold. Derived from the format's own limits rather than
+    // assumed, so a future change to QuantizationA is caught here instead of
+    // silently reopening the overflow this bound exists to close.
+    inline constexpr int64_t MaxActivatedTermMagnitude =
+        static_cast<int64_t>(Architecture::QuantizationA) * 32768;
+
+    // Largest number of ActivatedDotProduct terms a kernel may sum in int32
+    // before it must widen to Accumulation, for any int16 weight the format
+    // permits -- not merely the weights a trained network happens to
+    // produce. A kernel accumulates whole vectors at a time, so this only
+    // needs to be a safe lower bound, not the tightest one.
+    inline constexpr size_t MaxSafeChunkTerms =
+        static_cast<size_t>(INT32_MAX / MaxActivatedTermMagnitude);
+
+    // The chunk size ActivatedDotProduct kernels actually use: half of
+    // HiddenSize, comfortably inside MaxSafeChunkTerms and a whole multiple
+    // of every kernel's vector width.
+    inline constexpr size_t ActivationChunk = 256;
+
+    static_assert(ActivationChunk <= MaxSafeChunkTerms,
+        "ActivationChunk terms must fit in int32 for any int16 weight the format permits");
+    static_assert(Architecture::HiddenSize % ActivationChunk == 0,
+        "ActivatedDotProduct's only production caller passes HiddenSize terms");
 
     // Converts a weighted sum of activations into a centipawn score from the
     // point of view of the side to move.
     constexpr Score Dequantize(Accumulation weightedSum, int32_t outputBias)
     {
-        const Accumulation normalized = weightedSum / ActivationScale + outputBias;
+        const Accumulation normalized = weightedSum + outputBias;
         const Accumulation scaled = normalized * Architecture::EvalScale /
             (static_cast<Accumulation>(Architecture::QuantizationA) * Architecture::QuantizationB);
         return static_cast<Score>(scaled);

--- a/NeraChessNNUE/src/SimdOps.h
+++ b/NeraChessNNUE/src/SimdOps.h
@@ -105,13 +105,30 @@ namespace NeraChessNNUE::Simd
             }
         }
 
+        // Activate already rescales its result onto [0, QuantizationA], so
+        // each term fits int32 with room to spare; only a run of them needs
+        // widening. Summing Quantization::ActivationChunk terms at a time in
+        // int32 before folding into the int64 total is safe for any int16
+        // weight the format permits (see Quantization::MaxSafeChunkTerms) and
+        // -- because plain integer addition is associative and none of these
+        // partial sums can overflow -- gives the same total as adding every
+        // term into the int64 accumulator directly.
         inline Accumulation ActivatedDotProduct(const Weight* values, const Weight* weights,
             size_t count)
         {
-            Accumulation sum = 0;
-            for (size_t index = 0; index < count; ++index)
-                sum += Quantization::Activate(values[index]) * weights[index];
-            return sum;
+            Accumulation total = 0;
+            size_t index = 0;
+            for (; index + Quantization::ActivationChunk <= count; index += Quantization::ActivationChunk)
+            {
+                int32_t chunk = 0;
+                for (size_t offset = 0; offset < Quantization::ActivationChunk; ++offset)
+                    chunk += Quantization::Activate(values[index + offset]) * weights[index + offset];
+                total += chunk;
+            }
+            int32_t tail = 0;
+            for (; index < count; ++index)
+                tail += Quantization::Activate(values[index]) * weights[index];
+            return total + tail;
         }
     }
 
@@ -144,28 +161,49 @@ namespace NeraChessNNUE::Simd
     {
         // Each tier below is bit-exact with Scalar::ActivatedDotProduct by
         // construction: it is the identical loop, recompiled at a wider
-        // target so the vectorizer reassociates the additions. That is safe
-        // because no reassociation can overflow -- a squared clip times an
-        // int16 weight fits in int32, and the running int64 total cannot
-        // overflow for any int16 weight the format permits (at most 512
-        // terms, each under 65025 * 32767 < 2^31) -- so every grouping of the
-        // sum produces the same int64 value.
+        // target so the vectorizer reassociates the additions and, for the
+        // activation's division, lowers a compile-time-constant unsigned
+        // divide into a reciprocal-multiply sequence. That reassociation is
+        // safe because no intermediate can overflow -- Activate's result
+        // fits int32 with room to spare, a chunk of Quantization::
+        // ActivationChunk terms cannot overflow int32 for any int16 weight
+        // the format permits, and plain integer addition of exact terms
+        // produces the same total regardless of grouping -- so every
+        // grouping of the sum produces the same int64 value.
         __attribute__((target("avx2")))
         inline Accumulation DotAvx2(const Weight* values, const Weight* weights, size_t count)
         {
-            Accumulation sum = 0;
-            for (size_t index = 0; index < count; ++index)
-                sum += Quantization::Activate(values[index]) * weights[index];
-            return sum;
+            Accumulation total = 0;
+            size_t index = 0;
+            for (; index + Quantization::ActivationChunk <= count; index += Quantization::ActivationChunk)
+            {
+                int32_t chunk = 0;
+                for (size_t offset = 0; offset < Quantization::ActivationChunk; ++offset)
+                    chunk += Quantization::Activate(values[index + offset]) * weights[index + offset];
+                total += chunk;
+            }
+            int32_t tail = 0;
+            for (; index < count; ++index)
+                tail += Quantization::Activate(values[index]) * weights[index];
+            return total + tail;
         }
 
         __attribute__((target("sse4.1")))
         inline Accumulation DotSse41(const Weight* values, const Weight* weights, size_t count)
         {
-            Accumulation sum = 0;
-            for (size_t index = 0; index < count; ++index)
-                sum += Quantization::Activate(values[index]) * weights[index];
-            return sum;
+            Accumulation total = 0;
+            size_t index = 0;
+            for (; index + Quantization::ActivationChunk <= count; index += Quantization::ActivationChunk)
+            {
+                int32_t chunk = 0;
+                for (size_t offset = 0; offset < Quantization::ActivationChunk; ++offset)
+                    chunk += Quantization::Activate(values[index + offset]) * weights[index + offset];
+                total += chunk;
+            }
+            int32_t tail = 0;
+            for (; index < count; ++index)
+                tail += Quantization::Activate(values[index]) * weights[index];
+            return total + tail;
         }
 
         // Add/Subtract/AddSubtract and the Copy* variants below already have a
@@ -571,11 +609,12 @@ namespace NeraChessNNUE::Simd
 
     // Sum of Activate(values[i]) * weights[i].
     //
-    // With squared clipped ReLU each term is clamp(v, 0, 255)^2 * w. The square
-    // is at most 65025 and the weight at most 32767 in magnitude, so a single
-    // term always fits in int32 -- but a sum of them does not, which is why the
-    // running total is widened to int64 rather than accumulated in int32 and
-    // widened at the end.
+    // Activate rescales the squared clip back onto [0, QuantizationA] (see
+    // Quantization.h), so a term is a single int16 x int16 -> int32 widening
+    // multiply-add instead of the int32 x int32 multiply a wider activation
+    // would need. A chunk of Quantization::ActivationChunk terms cannot
+    // overflow int32 for any int16 weight the format permits, so the running
+    // total only needs to widen to int64 once per chunk rather than per term.
     inline Accumulation ActivatedDotProduct(const Weight* values, const Weight* weights,
         size_t count)
     {
@@ -583,52 +622,94 @@ namespace NeraChessNNUE::Simd
         static_assert(Architecture::Activation ==
             Architecture::ActivationKind::SquaredClippedReLU,
             "the NEON kernel implements squared clipped ReLU");
+        static_assert(Architecture::QuantizationA == 255,
+            "the NEON activation divide is the exact bit trick for /255 specifically");
+
+        constexpr size_t VectorWidth = 8;
+        constexpr size_t VectorsPerChunk = Quantization::ActivationChunk / VectorWidth;
+        static_assert(Quantization::ActivationChunk % VectorWidth == 0,
+            "ActivationChunk must be a whole number of NEON vectors");
 
         const int16x8_t zero = vdupq_n_s16(0);
         const int16x8_t ceiling = vdupq_n_s16(
             static_cast<int16_t>(Architecture::QuantizationA));
-        int64x2_t total0 = vdupq_n_s64(0);
-        int64x2_t total1 = vdupq_n_s64(0);
+        const uint16x8_t one = vdupq_n_u16(1);
+
+        Accumulation total = 0;
+        int32x4_t chunkLow = vdupq_n_s32(0);
+        int32x4_t chunkHigh = vdupq_n_s32(0);
+        size_t vectorsInChunk = 0;
 
         size_t index = 0;
-        for (; index + 8 <= count; index += 8)
+        for (; index + VectorWidth <= count; index += VectorWidth)
         {
             const int16x8_t clipped = vminq_s16(
                 vmaxq_s16(vld1q_s16(values + index), zero), ceiling);
             const int16x8_t weight = vld1q_s16(weights + index);
 
-            // Widening multiplies: int16 x int16 -> int32, exact by construction.
-            const int32x4_t squareLow = vmull_s16(vget_low_s16(clipped), vget_low_s16(clipped));
-            const int32x4_t squareHigh = vmull_high_s16(clipped, clipped);
-            const int32x4_t weightLow = vmovl_s16(vget_low_s16(weight));
-            const int32x4_t weightHigh = vmovl_high_s16(weight);
+            // clipped^2 <= 255^2 = 65025 fits the low 16 bits of the packed
+            // multiply exactly (no widening needed), so this is the same bit
+            // pattern as an unsigned squaring would produce.
+            const uint16x8_t square = vreinterpretq_u16_s16(vmulq_s16(clipped, clipped));
 
-            // Each product fits in int32; widen before summing so the running
-            // total cannot overflow.
-            const int32x4_t productLow = vmulq_s32(squareLow, weightLow);
-            const int32x4_t productHigh = vmulq_s32(squareHigh, weightHigh);
+            // Exact unsigned division by 255 for any 16-bit value: floor(x / 255)
+            // == ((x + 1) + ((x + 1) >> 8)) >> 8, verified exhaustively over
+            // [0, 65535]. Logical (not arithmetic) shifts, hence the unsigned type.
+            const uint16x8_t biased = vaddq_u16(square, one);
+            const uint16x8_t activatedU =
+                vshrq_n_u16(vaddq_u16(biased, vshrq_n_u16(biased, 8)), 8);
+            const int16x8_t activated = vreinterpretq_s16_u16(activatedU);
 
-            total0 = vaddq_s64(total0, vmovl_s32(vget_low_s32(productLow)));
-            total1 = vaddq_s64(total1, vmovl_high_s32(productLow));
-            total0 = vaddq_s64(total0, vmovl_s32(vget_low_s32(productHigh)));
-            total1 = vaddq_s64(total1, vmovl_high_s32(productHigh));
+            // Widening multiply-accumulate: int16 x int16 -> int32, exact
+            // because activated <= QuantizationA and the weight magnitude is
+            // bounded to fit int16, so one product cannot overflow int32.
+            chunkLow = vmlal_s16(chunkLow, vget_low_s16(activated), vget_low_s16(weight));
+            chunkHigh = vmlal_high_s16(chunkHigh, activated, weight);
+
+            if (++vectorsInChunk == VectorsPerChunk)
+            {
+                total += vaddvq_s32(vaddq_s32(chunkLow, chunkHigh));
+                chunkLow = vdupq_n_s32(0);
+                chunkHigh = vdupq_n_s32(0);
+                vectorsInChunk = 0;
+            }
         }
 
-        const int64x2_t combined = vaddq_s64(total0, total1);
-        Accumulation sum = vgetq_lane_s64(combined, 0) + vgetq_lane_s64(combined, 1);
-        return sum + Scalar::ActivatedDotProduct(values + index, weights + index, count - index);
+        total += vaddvq_s32(vaddq_s32(chunkLow, chunkHigh));
+        return total + Scalar::ActivatedDotProduct(values + index, weights + index, count - index);
 #elif defined(NNUE_SIMD_AVX2)
         static_assert(Architecture::Activation ==
             Architecture::ActivationKind::SquaredClippedReLU,
             "the AVX2 kernel implements squared clipped ReLU");
+        static_assert(Architecture::QuantizationA == 255,
+            "the AVX2 activation divide is the exact bit trick for /255 specifically");
+
+        constexpr size_t VectorWidth = 16;
+        constexpr size_t VectorsPerChunk = Quantization::ActivationChunk / VectorWidth;
+        static_assert(Quantization::ActivationChunk % VectorWidth == 0,
+            "ActivationChunk must be a whole number of AVX2 vectors");
 
         const __m256i zero = _mm256_setzero_si256();
         const __m256i ceiling = _mm256_set1_epi16(
             static_cast<short>(Architecture::QuantizationA));
-        __m256i total = _mm256_setzero_si256();
+        const __m256i one = _mm256_set1_epi16(1);
+
+        const auto horizontalSum = [](__m256i vector) -> Accumulation
+        {
+            alignas(32) int32_t lanes[8];
+            _mm256_store_si256(reinterpret_cast<__m256i*>(lanes), vector);
+            Accumulation sum = 0;
+            for (const int32_t lane : lanes)
+                sum += lane;
+            return sum;
+        };
+
+        Accumulation total = 0;
+        __m256i chunkTotal = _mm256_setzero_si256();
+        size_t vectorsInChunk = 0;
 
         size_t index = 0;
-        for (; index + 16 <= count; index += 16)
+        for (; index + VectorWidth <= count; index += VectorWidth)
         {
             const __m256i clipped = _mm256_min_epi16(
                 _mm256_max_epi16(
@@ -637,32 +718,35 @@ namespace NeraChessNNUE::Simd
             const __m256i weight =
                 _mm256_loadu_si256(reinterpret_cast<const __m256i*>(weights + index));
 
-            // Widen to int32 in two halves; the square and the product both fit.
-            for (int half = 0; half < 2; ++half)
+            // clipped^2 <= 255^2 = 65025 fits the low 16 bits of the packed
+            // multiply exactly (no widening needed), so this is the same bit
+            // pattern as an unsigned squaring would produce.
+            const __m256i square = _mm256_mullo_epi16(clipped, clipped);
+
+            // Exact unsigned division by 255 for any 16-bit value: floor(x / 255)
+            // == ((x + 1) + ((x + 1) >> 8)) >> 8, verified exhaustively over
+            // [0, 65535]. _mm256_srli_epi16 shifts logically, which is what makes
+            // this correct even though the biased value can look negative as int16.
+            const __m256i biased = _mm256_add_epi16(square, one);
+            const __m256i activated =
+                _mm256_srli_epi16(_mm256_add_epi16(biased, _mm256_srli_epi16(biased, 8)), 8);
+
+            // Widening multiply-add: sums each adjacent pair of int16 products
+            // into one int32 lane, exact because activated <= QuantizationA and
+            // the weight magnitude is bounded to fit int16, so neither a single
+            // product nor a pair of them can overflow int32.
+            chunkTotal = _mm256_add_epi32(chunkTotal, _mm256_madd_epi16(activated, weight));
+
+            if (++vectorsInChunk == VectorsPerChunk)
             {
-                const __m128i clippedHalf = half == 0
-                    ? _mm256_castsi256_si128(clipped)
-                    : _mm256_extracti128_si256(clipped, 1);
-                const __m128i weightHalf = half == 0
-                    ? _mm256_castsi256_si128(weight)
-                    : _mm256_extracti128_si256(weight, 1);
-
-                const __m256i wide = _mm256_cvtepi16_epi32(clippedHalf);
-                const __m256i wideWeight = _mm256_cvtepi16_epi32(weightHalf);
-                const __m256i square = _mm256_mullo_epi32(wide, wide);
-                const __m256i product = _mm256_mullo_epi32(square, wideWeight);
-
-                total = _mm256_add_epi64(total,
-                    _mm256_cvtepi32_epi64(_mm256_castsi256_si128(product)));
-                total = _mm256_add_epi64(total,
-                    _mm256_cvtepi32_epi64(_mm256_extracti128_si256(product, 1)));
+                total += horizontalSum(chunkTotal);
+                chunkTotal = _mm256_setzero_si256();
+                vectorsInChunk = 0;
             }
         }
 
-        alignas(32) int64_t lanes[4];
-        _mm256_store_si256(reinterpret_cast<__m256i*>(lanes), total);
-        const Accumulation sum = lanes[0] + lanes[1] + lanes[2] + lanes[3];
-        return sum + Scalar::ActivatedDotProduct(values + index, weights + index, count - index);
+        total += horizontalSum(chunkTotal);
+        return total + Scalar::ActivatedDotProduct(values + index, weights + index, count - index);
 #else
 #if defined(NNUE_SIMD_X86_DISPATCH)
         switch (Dispatch::SelectedTier())

--- a/docs/NNUE.md
+++ b/docs/NNUE.md
@@ -380,11 +380,32 @@ every reproduced game and every regression test machine-dependent.
 
 The kernels are therefore written so that no intermediate value can overflow
 for *any* int16 parameters the format permits, not merely for the small weights
-a trained network happens to produce. With squared clipped ReLU, one term is
-`clamp(v, 0, 255)^2 * w`: at most 65025 times 32767, which fits in int32 with
-almost nothing to spare, while a sum of a thousand such terms does not. The
-running total is therefore widened to int64 as it goes rather than accumulated
-in int32 and widened at the end.
+a trained network happens to produce.
+
+`Quantization::Activate` rescales its result back onto `[0, QuantizationA]`
+immediately, rather than leaving that division for `Dequantize` to do once at
+the very end. With squared clipped ReLU this makes a term
+`(clamp(v, 0, 255)^2 / 255) * w`: the activated value never exceeds
+`QuantizationA`, so it is a plain int16, and the product with an int16 weight
+is a single widening multiply that fits int32 with room to spare -- no wider
+than the original `clamp(v, 0, 255)^2 * w`, which peaked at 65025 * 32767, but
+now cheap enough to compute as `int16 x int16 -> int32` (AVX2 `vpmaddwd`, NEON
+`vmlal_s16`) instead of promoting both operands through int32 first. A sum of
+many such terms still does not fit int32, so kernels widen to int64 once every
+`Quantization::ActivationChunk` terms -- a bound derived from the format's own
+limits and static-asserted, not assumed -- rather than per term. Because plain
+integer addition of exact values is associative, this produces the same int64
+total as widening after every term would.
+
+The activation's division by `QuantizationA` (255) has no vectorized divide
+instruction to fall back on. The scalar and runtime-dispatch kernels write it
+as an ordinary unsigned 16-bit division and let the compiler lower it to a
+reciprocal-multiply sequence, the same way it would for a scalar loop; the
+hand-vectorized AVX2 and NEON kernels (needed because MSVC has no function
+multiversioning to fall back on) use the exact bit trick
+`floor(x / 255) == ((x + 1) + ((x + 1) >> 8)) >> 8`, verified exhaustively
+against plain division over the full 16-bit range rather than trusted from
+memory.
 
 `TestNnueSimdKernels` compares every kernel against the scalar reference on
 int16 extremes, the values either side of the activation's clipping ceiling,


### PR DESCRIPTION
Closes #27

## Summary

`Quantization::Activate` used to leave the squared-clipped-ReLU activation at the accumulator's squared scale and divide it back down once, at the very end, in `Dequantize`. It now divides immediately, so every activated value fits int16. That turns the output layer's per-term product from an int32×int32 multiply into a single int16×int16→int32 widening multiply-add (AVX2 `vpmaddwd`, NEON `vmlal_s16`), and lets the running total stay in int32 for a whole chunk of terms instead of widening to int64 after every one.

## Problem

Issue #27 measured `Simd::ActivatedDotProduct` (the NNUE output layer) at ~17-18% of search instructions in a callgrind profile — larger than move generation or move ordering. The kernel widened every term to int64 to accumulate safely, which cost 18 of 27 instructions per 16 elements: a 32-bit widening square, weights widened to int32 twice (once per SIMD half), a 32×32 multiply, and four `vpaddq`s to fold the product into an int64 running total.

## Implementation

- `Quantization::Activate` now divides `clamp(v, 0, QuantizationA)^2` by `QuantizationA` before returning, instead of `Dequantize` dividing the final sum once. The square and the division are both kept at uint16_t width (not widened to uint32_t) — at `QuantizationA <= 255` the square never exceeds 65025, so it fits exactly, and staying that narrow is what lets the compiler lower the divide to a cheap reciprocal-multiply instead of promoting through 32 bits.
- `Quantization::ActivationChunk` (256) is a chunk size derived from the format's own int16 limits and static-asserted safe, replacing the old "widen every term" approach. All four kernel tiers (scalar reference, the two SSE2-baseline runtime-dispatch clones, native AVX2, native NEON) sum a chunk of terms in int32 and only widen to `Accumulation` (int64) once per chunk.
- The two hand-vectorized kernels (AVX2, NEON — needed because MSVC has no function multiversioning to fall back on for the runtime-dispatch trick) implement the resulting divide-by-255 with the exact bit trick `floor(x/255) == ((x+1) + ((x+1)>>8)) >> 8`, since neither instruction set has a packed integer divide.
- `NNUETraining/nnue_training/quantize.py` (`activate`/`dequantize`) mirrors the new convention exactly.

## Why this approach

Reassociating a sum of exact integers into differently-sized chunks before widening doesn't change the total, provided no partial sum overflows — so every kernel can pick whatever chunk size suits its vector width without losing bit-exactness with the scalar reference, which `TestNnueSimdKernels` already checks. The scalar reference and the two dispatch clones are written as plain C++ (matching this file's existing "recompile the identical scalar loop at a wider target" philosophy) and rely on the vectorizer's own divide-by-constant lowering; only the two natively hand-vectorized kernels needed an explicit bit trick, since there's no vectorized divide instruction to fall back on.

I considered bumping `Architecture::ArchitectureHash()` for the rounding-convention change, but decided against it: the on-disk format and stored weights are completely unchanged (only the interpretation of an already-int16-representable intermediate shifts by a few centipawns), and the shipped network and the trainer's Python mirror move together in this same commit, so there's no scenario where an old-convention file meets a new-convention reader inside this repository.

## Validation

```
Release regression suite (default dispatch, kernels sse2 (dispatch: avx2)): PASS
Release regression suite (native -mavx2 build, kernels avx2): PASS
Debug + ASan/UBSan, with accumulator verification: PASS
Python test suite (NNUETraining, 82 tests): PASS
nnue_training.verify against the rebuilt engine (8 positions): all agree exactly
--nnue-feature-vectors: byte-identical to the committed feature_vectors.json
UCI pondering smoke test: PASS
```

NEON can't be exercised on this machine (no ARM hardware): the kernel was cross-compile-checked for `aarch64-linux-gnu` (correct intrinsic signatures, clean compile) and its exact per-lane arithmetic was reproduced in a portable C++ model, fuzzed against the scalar reference over 200,000 random trials plus the fully-saturated worst case — zero mismatches. It will also run for real on the macOS (Apple Silicon/NEON) CI job.

Benchmarks (this machine, Ubuntu, AVX2 dispatch tier):

```
Isolated ActivatedDotProduct microbenchmark (callgrind, 200,000 calls x 512 elements):
Before: 879 Ir/call
After:  451 Ir/call
Difference: -48.7%   (issue's own projection: -50.2%)

--nnue-bench incremental eval/s (kiwipete position, mean of 6 runs):
Before: ~2.39M eval/s
After:  ~2.83M eval/s
Difference: +18.5%
```

The end-to-end eval/s gain is smaller than the isolated kernel's because `ActivatedDotProduct` is only part of a full evaluation (accumulator refresh/update is untouched).

## Strength test

This is a rounding change (per-term truncation instead of one truncation at the end), so it shifts evaluations by a few centipawns and needed a real strength test, not just a bit-identical node-count check.

```
Strength test (sequential, .github/workflows/strength-test.yml):
Candidate: 65412e777c8de7197e3f4aa0cdc5f403cee18bac
Baseline:  06a32e91baab9b4d440c98a8cbe11a972cb9f187 (main)
Time control: 10+0.1
Games: 4000 (stopped early; sequential test reached a decision after stage 3)
W/D/L: 1196 / 1826 / 978
Candidate score: 52.73%
Estimated Elo: +19.0
Approximate paired 95% interval: [+12.2, +25.7]
Stopping rule: SPRT H0: Elo <= 0 vs H1: Elo >= 5, alpha=0.05, beta=0.05 -- LLR +6.92, crossed the +2.94 accept boundary
Result: Accepted: improvement
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/33147558595
```

## Risks

- This is a genuine rounding-convention change to the network's arithmetic, not a bit-identical refactor — a network file's evaluation on identical weights shifts by a few centipawns from before. The strength test above is the guard against that costing anything, and it didn't.
- The two hand-vectorized kernels (AVX2, NEON) now depend on `Architecture::QuantizationA == 255` specifically for their bit-trick division; both carry a `static_assert` that will fail loudly if that constant ever changes, rather than silently miscomputing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VQt4YhNPZWTN2jGhKfCZqP)_