### PR TITLE
Keep a proven root fail-high when the clock aborts the re-search

### DIFF
--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -277,6 +277,16 @@ namespace NeraChessSearch
             Score alpha = window == SCORE_INF ? -SCORE_INF : previousScore - window;
             Score beta = window == SCORE_INF ? SCORE_INF : previousScore + window;
             RootResult iteration;
+            // A root fail-high (score >= beta) proves its move is worth at least beta
+            // at this depth, and by the time SearchRoot returns it,
+            // UpdatePrincipalVariation(0, move) has already filled m_PvTable[0] with a
+            // valid line for it. That evidence stays true even if the widened re-search
+            // below is interrupted, so it is kept separately: the re-search's own
+            // SearchRoot call clears m_PvLength[0] as soon as it starts, and an aborted
+            // `iteration` carries no move at all (SearchRoot returns early on abort,
+            // before folding the in-flight move into its result).
+            RootResult rootFailHigh;
+            std::vector<Move> rootFailHighPV;
 
             while (true)
             {
@@ -285,6 +295,13 @@ namespace NeraChessSearch
                     break;
                 if (iteration.score > alpha && iteration.score < beta)
                     break;
+
+                if (iteration.score >= beta)
+                {
+                    rootFailHigh = iteration;
+                    rootFailHighPV.assign(m_PvTable[0].begin(),
+                        m_PvTable[0].begin() + m_PvLength[0]);
+                }
 
                 window = std::min<Score>(SCORE_INF, window * 2);
                 alpha = window == SCORE_INF
@@ -296,7 +313,27 @@ namespace NeraChessSearch
             }
 
             if (m_Aborted)
+            {
+                // The clock cut off this depth's re-search, but a fail-high proved
+                // earlier at this same depth is still sound: keep it instead of
+                // falling back to the previous, shallower iteration's move.
+                if (rootFailHigh.move != 0)
+                {
+                    result.bestMove = rootFailHigh.move;
+                    result.score = rootFailHigh.score;
+                    result.completedDepth = depth;
+                    result.completed = true;
+                    result.principalVariation = std::move(rootFailHighPV);
+                    result.nodes = AggregateNodeCount();
+                    result.selectiveDepth = m_SelectiveDepth;
+                    result.hashFullPermill = m_TranspositionTable->HashFullPermill();
+                    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - m_StartTime);
+                    if (m_Limits.iterationCallback)
+                        m_Limits.iterationCallback(result);
+                }
                 break;
+            }
 
             result.bestMove = iteration.move;
             result.score = iteration.score;


### PR DESCRIPTION
## Summary

`SearchEngine::SearchWorker`'s aspiration-window loop discarded the entire final iteration whenever the clock aborted it, even when that iteration had already proved a root fail-high (a completed root move scoring `>= beta`) before the widened re-search that followed was the one actually cut off. This change preserves that fail-high move and its principal variation instead of silently falling back to the previous, shallower iteration's move.

## Problem

Closes #30.

In `NeraChessSearch/src/SearchEngine.cpp`, the per-depth aspiration-window loop looks like:

```cpp
while (true)
{
    iteration = SearchRoot(board, depth, alpha, beta);
    if (m_Aborted)
        break;
    if (iteration.score > alpha && iteration.score < beta)
        break;
    // widen and retry
}
if (m_Aborted)
    break;               // `iteration` (and any prior fail-high) discarded here
result.bestMove = iteration.move;
```

When a `SearchRoot` call returns a fail-high (`score >= beta`), the move that caused it is fully proven at this depth — `SearchRoot` only assigns `result.move`/`result.score` for root moves whose subtree was searched to completion, and `UpdatePrincipalVariation(0, move)` has already recorded a valid PV for it. The loop then widens the window and calls `SearchRoot` again. If *that* call is the one the clock aborts, the fail-high evidence is lost: the widened `SearchRoot` resets `m_PvLength[0]` to zero as soon as it starts, and returns an empty, aborted `RootResult`. The outer `if (m_Aborted) break;` then leaves `result` exactly as the previous, shallower iteration left it — even though this depth already proved a stronger move.

The issue measured this on real self-play searches at a `10+0.1`-like budget: 93.9% of searches ended on an aborted iteration, and in about 5.8% of them the move actually played contradicted the engine's own deepest evidence.

## Implementation

Track the most recent root fail-high separately from the in-flight aspiration attempt:

```cpp
RootResult rootFailHigh;
std::vector<Move> rootFailHighPV;
...
if (iteration.score >= beta)
{
    rootFailHigh = iteration;
    rootFailHighPV.assign(m_PvTable[0].begin(), m_PvTable[0].begin() + m_PvLength[0]);
}
```

The PV is copied out immediately, before the next (possibly aborted) `SearchRoot` call can clear `m_PvLength[0]`. If the widened re-search is the one that gets aborted, `rootFailHigh` (if any) becomes the depth's result instead of falling through to the previous iteration:

```cpp
if (m_Aborted)
{
    if (rootFailHigh.move != 0)
    {
        result.bestMove = rootFailHigh.move;
        result.score = rootFailHigh.score;
        result.completedDepth = depth;
        result.principalVariation = std::move(rootFailHighPV);
        ...
        if (m_Limits.iterationCallback)
            m_Limits.iterationCallback(result);
    }
    break;
}
```

Calling `iterationCallback` here keeps the last emitted UCI `info` line consistent with the eventual `bestmove` — the same invariant the normal, non-aborted path already maintains.

## Why this approach

The issue's write-up lays out several possible scopes (fail-high-only, or the general case of any partial best-so-far root move), and explicitly recommends starting with the fail-high-only variant: it's the narrowest change, and the best-justified one, since a fail-high move is proven to be *at least* as good as the previous best (`score >= beta = previousScore + window`), whereas an arbitrary partial best-so-far after only one or two root moves is closer to arbitrary and carries real regression risk. This PR implements only the fail-high case; the general partial-iteration case is left for separate follow-up experimentation, per the issue.

## Validation

```
Release regression suite (--eval-file nera.nnue): PASS
Debug regression suite, accumulator-verification asserts on: PASS
UCI pondering smoke test (scripts/Test-UciPonder.py): PASS
```

Fixed-depth (`go depth N`, no node/time cap) searches are byte-identical to `main` across several test positions — node counts, scores, and PVs match exactly, only NPS timing varies, confirming the abort path is never taken there and behavior is unaffected.

Directly exercised the salvage path with a temporarily instrumented debug build against short `movetime` searches with the opening book disabled. It fires as intended and reproduces exactly the scenario described in the issue — e.g. one case: depth 3 had settled on `a2a3`, depth 4 proved a fail-high on `e2d3` before the widened re-search was aborted, and the engine now reports `e2d3` (matching its own deepest evidence) instead of the stale `a2a3`.

### Strength test

```
Games: 2000 (sequential SPRT, stopped early — decisive after stage 2 of 7)
Time control: 10+0.1
Candidate: 9a411f582754bc2c9d0d2de859399a293aeb2ad6
Baseline:  140fb226a82d67559786997e13c720b1c1b52227 (main)
W/D/L: 587 / 920 / 493
Candidate score: 52.35%
Estimated Elo: +16.3
Approximate paired 95% interval: [+6.8, +25.9]
Stopping rule: SPRT H0: Elo <= 0 vs H1: Elo >= 5, alpha = 0.05, beta = 0.05
Result: Accepted: improvement
Workflow: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/33433140724
```

This is a screening-test result at `10+0.1`, not a definitive measurement of the exact Elo gain, but it clears the sequential test's acceptance boundary rather than merely showing a positive point estimate.

## Risks

- Only the fail-high case is handled; a partial (non-fail-high) best-so-far root move at an aborted depth is still discarded exactly as before. This is deliberate — see "Why this approach" — but means the fix only recovers part of the discarded search time the issue measured (~12% of searches had a final-depth fail-high; the rest are unaffected by this change).
- The salvaged result's principal variation can be shorter than a normal completed iteration's PV (in the fail-high case observed during testing, PV length was sometimes just the single root move), since PV-table population on a fail-high path is inherently shallower than on a fully resolved PV node. This only affects the ponder-move suggestion, not correctness of the move played.
- `go nodes N` (node-limited, not just time-limited) searches also exercise `m_Aborted` via the node-count check in `ShouldStop()`, so their output can now legitimately differ from `main` when a fail-high is salvaged. This is intended — the same fix that helps clock-limited play also helps node-limited analysis — but is worth noting since the issue's validation section frames "fixed-node" searches as expected to be unchanged; that only holds when no node cap is actually set.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NEebZ5TbXMThUudcpfhUJC)_