### PR TITLE
Reuse quiescence SEE scores computed during move ordering

### DIFF
--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -791,10 +791,12 @@ namespace NeraChessSearch
             if (inCheck || !IsQuiet(move))
                 candidates.push(move);
         }
-        SortMoves(board, candidates, ply, ttMove);
+        std::array<int32_t, 218> seeValues{};
+        SortMoves(board, candidates, ply, ttMove, 0, &seeValues);
 
-        for (const Move move : candidates)
+        for (size_t i = 0; i < candidates.size(); ++i)
         {
+            const Move move = candidates[i];
             if (!inCheck && !(move.GetMoveFlags() & MoveFlags::IS_PROMOTION))
             {
                 const Piece victim = (move.GetMoveFlags() & MoveFlags::IS_EN_PASSANT)
@@ -802,7 +804,7 @@ namespace NeraChessSearch
                         ? PieceType::BLACK_PAWN : PieceType::WHITE_PAWN)
                     : board.GetPiece(move.GetTargetSquare());
                 const bool deltaPrunable = standPat + PieceValue(victim) + 200 < alpha;
-                const bool seePrunable = MoveOrdering::StaticExchangeEvaluation(board, move) < -50;
+                const bool seePrunable = seeValues[i] < -50;
 
                 // Deciding this before MakeSearchMove avoids paying for the accumulator
                 // push and a full legal-move generation of the child position on a move
@@ -846,30 +848,43 @@ namespace NeraChessSearch
     }
 
     void SearchEngine::SortMoves(const ChessBoard& board, MoveList<218>& moves,
-        int ply, Move ttMove, Move previousMove)
+        int ply, Move ttMove, Move previousMove, std::array<int32_t, 218>* seeValues)
     {
         std::array<int32_t, 218> scores{};
+        std::array<int32_t, 218> see{};
         const Move counterMove = GetCounterMove(previousMove);
         const uint8_t side = board.GetBoardState().HasFlag(BoardStateFlags::WhiteToMove) ? 0 : 1;
         for (size_t i = 0; i < moves.size(); ++i)
         {
             const Move move = moves[i];
             int32_t score = 0;
-            if (move == ttMove)
+            const bool isTTMove = move == ttMove;
+            const bool isCapture = move.GetMoveFlags() & MoveFlags::IS_CAPTURE;
+
+            // The TT move's ordering score is fixed regardless of its SEE, so its
+            // exchange is only evaluated here when the caller (quiescence pruning)
+            // asked for every candidate's value; otherwise it stays unscored, same
+            // as before this value was made available to callers.
+            if (isCapture && (!isTTMove || seeValues))
+            {
+                const Piece victim = (move.GetMoveFlags() & MoveFlags::IS_EN_PASSANT)
+                    ? Piece(move.GetMovePiece().IsWhite() ? PieceType::BLACK_PAWN : PieceType::WHITE_PAWN)
+                    : board.GetPiece(move.GetTargetSquare());
+                const int captureSee = MoveOrdering::StaticExchangeEvaluation(board, move);
+                see[i] = captureSee;
+                if (!isTTMove)
+                {
+                    score += (captureSee >= 0 ? 10'000'000 : 5'000'000) +
+                        PieceValue(victim) * 16 - PieceValue(move.GetMovePiece()) + captureSee;
+                }
+            }
+
+            if (isTTMove)
             {
                 scores[i] = 20'000'000;
                 continue;
             }
 
-            if (move.GetMoveFlags() & MoveFlags::IS_CAPTURE)
-            {
-                const Piece victim = (move.GetMoveFlags() & MoveFlags::IS_EN_PASSANT)
-                    ? Piece(move.GetMovePiece().IsWhite() ? PieceType::BLACK_PAWN : PieceType::WHITE_PAWN)
-                    : board.GetPiece(move.GetTargetSquare());
-                const int see = MoveOrdering::StaticExchangeEvaluation(board, move);
-                score += (see >= 0 ? 10'000'000 : 5'000'000) +
-                    PieceValue(victim) * 16 - PieceValue(move.GetMovePiece()) + see;
-            }
             if (move.GetMoveFlags() & MoveFlags::IS_PROMOTION)
                 score += 9'000'000 + PieceValue(move.GetPromoPiece());
 
@@ -890,16 +905,22 @@ namespace NeraChessSearch
         {
             const Move move = moves[i];
             const int32_t score = scores[i];
+            const int32_t moveSee = see[i];
             size_t j = i;
             while (j > 0 && scores[j - 1] < score)
             {
                 scores[j] = scores[j - 1];
+                see[j] = see[j - 1];
                 moves[j] = moves[j - 1];
                 --j;
             }
             scores[j] = score;
+            see[j] = moveSee;
             moves[j] = move;
         }
+
+        if (seeValues)
+            *seeValues = see;
     }
 
     void SearchEngine::UpdatePrincipalVariation(int ply, Move move)

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -95,9 +95,13 @@ namespace NeraChessSearch
             NeraChessEngine::Move previousMove, bool cutNode);
         Score QuiescenceSearch(NeraChessEngine::ChessBoard& board, Score alpha, Score beta, int ply);
 
+        // seeValues, when non-null, receives the static-exchange score computed for each
+        // capture while scoring it for ordering, reordered in step with moves so the
+        // caller can reuse it (e.g. for SEE pruning) instead of recomputing it.
         void SortMoves(const NeraChessEngine::ChessBoard& board,
             NeraChessEngine::MoveList<218>& moves, int ply, NeraChessEngine::Move ttMove,
-            NeraChessEngine::Move previousMove = 0);
+            NeraChessEngine::Move previousMove = 0,
+            std::array<int32_t, 218>* seeValues = nullptr);
         // Evaluation of the node the search is standing on, using this
         // worker's accumulator stack.
         Score EvaluateNode(const NeraChessEngine::ChessBoard& board);


### PR DESCRIPTION
## Summary

Quiescence search's SEE-pruning check recomputed `MoveOrdering::StaticExchangeEvaluation` for every capture it examines, even though `SortMoves` had already computed the exact same value for that move moments earlier while scoring it for ordering. `SortMoves` now optionally hands back the per-move SEE values it computed, reordered in step with the sorted move list, and quiescence reads the cached value instead of recomputing the exchange.

Implements part (b) of #33 ("Reuse the SEE the sort already computed").

## Problem

`NeraChessSearch/src/SearchEngine.cpp`, `SortMoves` (called from quiescence at line 794) computes an exact SEE for every capture to build its ordering score. Moments later, the quiescence move loop (line 805, pre-change) called `StaticExchangeEvaluation` again on the same move to decide whether it's prunable (`see < -50`). Issue #33 profiled `SortMoves` at 26.2% of search instructions, with SEE itself at 12.1%, and identified this specific redundant call as ~19M Ir of pure waste with zero ordering benefit.

## Implementation

- `SortMoves` gained an optional `std::array<int32_t, 218>* seeValues` out-parameter. When a capture's SEE is computed for scoring, it's also written into a parallel `see` array that gets permuted in lock-step with `scores`/`moves` during the insertion sort, so `seeValues[i]` lines up with the sorted `moves[i]` the caller already has.
- `QuiescenceSearch` passes a local `seeValues` array into `SortMoves` and reads `seeValues[i]` in its pruning check instead of calling `StaticExchangeEvaluation` again.
- One subtlety: `SortMoves` previously skipped scoring the TT move's capture entirely (its ordering score is the fixed constant `20'000'000`, so there was nothing to compute). But the old quiescence loop *did* call `StaticExchangeEvaluation` unconditionally for every candidate, TT move included, for the pruning decision. To keep `seeValues` correct for every index, `SortMoves` now evaluates the TT move's exchange too, but only when a caller actually asked for `seeValues` (i.e. only from quiescence) — main search's `SortMoves` calls pass `nullptr` and keep skipping it exactly as before. So the total number of `StaticExchangeEvaluation` calls is unchanged for the TT-move case and reduced by exactly one per non-TT capture elsewhere.

## Why this approach

This is the "free" part of #33: it changes nothing about move ordering, pruning thresholds, or search behavior — it only avoids doing the same exact-SEE computation twice. The issue's own validation bar for this class of change is node-count identity, not a strength test (see Validation below).

## Validation

```
Release build (Engine/NNUE/Search/UCI/Tests): PASS
NeraChessTests (incl. TestStaticExchangeEvaluation, perft): PASS
UCI pondering regression (scripts/Test-UciPonder.py): PASS
```

**Tree identity** — fixed-depth (`go depth 10`, single thread, book off) search on 5 probe positions (startpos, kiwipete, a QGD-ish middlegame, the Lasker endgame `8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8`, a Ruy Lopez middlegame) against `origin/main` (`43297be`): **node counts, scores, and PVs bit-identical** on every position.

**Instruction count** (callgrind, `Ir`, single position — kiwipete, depth 9, single thread):
```
Baseline (43297be): 1,324,750,406 Ir
Candidate:           1,322,634,807 Ir
Difference:          -2,115,599 Ir (-0.16% of total, which includes ~145M Ir of one-time network load per #33's own measurement — a larger share of search-only instructions)
```

Reproduced twice on the candidate; identical Ir count both times (deterministic).

## Strength test

Not run. Per #33's own validation section: "(a) and (b) need no strength test if trees are provably identical... For (a) + (b): identical node counts on every test position, and a measurable drop in total instructions... Keep the change if instructions fall and node counts do not move." That is exactly what's demonstrated above — this change cannot alter move selection at any search depth (proven by bit-identical node counts/scores/PVs across 5 positions), so a 1,000-game screening match has nothing behavioral to measure, and the effect on real-time search speed here is small enough (a fraction of a percent) to be far below what 1,000 games at 10+0.1 could resolve anyway.

## Risks

- The TT-move special-case in `SortMoves` (only evaluate its SEE when `seeValues` is requested) is the one place this touches call counts rather than just relocating an existing call; verified via the node-count/PV comparison above and via `TestStaticExchangeEvaluation`.
- Part (a) of #33 (cheapening `StaticExchangeEvaluation` itself with incremental attacker bitboards) and part (c) (a staged/lazy picker, which changes ordering and needs its own SPRT) are out of scope for this PR — #33 treats them as separate, independently-validated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lna69xXZfu6MwcagSQTbQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lna69xXZfu6MwcagSQTbQz)_