### PR TITLE
Cut redundant work in move generation's emit loops

### DIFF
--- a/NeraChessEngine/src/ChessBoard.cpp
+++ b/NeraChessEngine/src/ChessBoard.cpp
@@ -612,22 +612,18 @@ namespace NeraChessEngine
 	{
 		if (m_WasBoardStateChanged)
 		{
-			m_LegalMoves = m_MoveGenerator.GenerateMoves(m_BoardState);
+			m_MoveGenerator.GenerateMoves(m_BoardState);
 			m_WasBoardStateChanged = false;
 		}
-		return m_LegalMoves;
+		return m_MoveGenerator.GetLegalMoves();
 	}
 
 	uint16_t ChessBoard::GetGameOver(bool gameCheck) const
 	{
 		uint16_t flags = GameOverFlags::IS_GAME_OVER;
-		if (m_WasBoardStateChanged)
-		{
-			m_LegalMoves = m_MoveGenerator.GenerateMoves(m_BoardState);
-			m_WasBoardStateChanged = false;
-		}	
-	
-		if (m_LegalMoves.size() == 0)
+		const MoveList<218>& legalMoves = GetLegalMovesRef();
+
+		if (legalMoves.size() == 0)
 		{
 
 			if (m_MoveGenerator.InCheck())
@@ -962,7 +958,7 @@ namespace NeraChessEngine
 	{
 		if (m_WasBoardStateChanged)
 		{
-			m_LegalMoves = m_MoveGenerator.GenerateMoves(m_BoardState);
+			m_MoveGenerator.GenerateMoves(m_BoardState);
 			m_WasBoardStateChanged = false;
 		}
 		return m_MoveGenerator.InCheck();

--- a/NeraChessEngine/src/ChessBoard.h
+++ b/NeraChessEngine/src/ChessBoard.h
@@ -49,7 +49,8 @@ namespace NeraChessEngine
 
 	    // Same legal moves as GetLegalMoves(), without the ~880-byte copy -- for
 	    // callers that only read the list (e.g. filtering into a shorter list) and
-	    // never hold onto it past the next move made on this board.
+	    // never hold onto it past the next move made on this board. Backed directly
+	    // by the MoveGenerator's own list -- ChessBoard keeps no second copy.
 	    const MoveList<218>& GetLegalMovesRef() const;
 
         void MakeMove(Move move, bool gameMove = false);
@@ -121,7 +122,6 @@ namespace NeraChessEngine
 
         mutable MoveGenerator m_MoveGenerator;
 
-	    mutable MoveList<218> m_LegalMoves{};
 	    mutable bool m_WasBoardStateChanged = true;
 
 	    mutable uint64_t m_ZobristKey = 0;

--- a/NeraChessEngine/src/MoveGenerator.cpp
+++ b/NeraChessEngine/src/MoveGenerator.cpp
@@ -461,7 +461,7 @@ namespace NeraChessEngine
 
 	const std::array<std::array<Bitboard, 64>, 64> MoveGenerator::s_AlignMask = InitAlignMask();
 
-	MoveList<218> MoveGenerator::GenerateMoves(const BoardState& board)
+	const MoveList<218>& MoveGenerator::GenerateMoves(const BoardState& board)
 	{
 		m_BoardState = board;
 
@@ -724,15 +724,19 @@ namespace NeraChessEngine
 		Bitboard legalMask = ~(m_OpponentAttackMap | m_FriendlyPieces);
 		Bitboard kingMoves = s_KingMoveMask[m_FriendlyKingSquare] & legalMask;
 
+		PieceType friendlyKingPiece = m_WhiteToMove ? PieceType::WHITE_KING : PieceType::BLACK_KING;
+
 		while (kingMoves != 0)
 		{
 			int targetSquare = BitUtil::PopLSB(kingMoves);
+			// legalMask already excludes friendly pieces, so an occupied target here
+			// is necessarily an opponent piece -- no need to look it up.
 			m_LegalMoves.push(Move(
-				m_FriendlyKingSquare, 
-				targetSquare, 
-				m_WhiteToMove ? PieceType::WHITE_KING : PieceType::BLACK_KING,
+				m_FriendlyKingSquare,
+				targetSquare,
+				friendlyKingPiece,
 				0,
-				GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE
+				Square(targetSquare).ContainsSquare(m_OpponentPieces) ? MoveFlags::IS_CAPTURE : 0
 			));
 		}
 
@@ -749,9 +753,9 @@ namespace NeraChessEngine
 			{
 				int targetSquare = m_WhiteToMove ? Square::g1 : Square::g8;
 				m_LegalMoves.push(Move(
-					m_FriendlyKingSquare, 
+					m_FriendlyKingSquare,
 					targetSquare,
-					GetPiece(m_FriendlyKingSquare),
+					friendlyKingPiece,
 					0,
 					MoveFlags::IS_CASTLES
 				));
@@ -769,7 +773,7 @@ namespace NeraChessEngine
 				m_LegalMoves.push(Move(
 					m_FriendlyKingSquare,
 					targetSquare,
-					GetPiece(m_FriendlyKingSquare),
+					friendlyKingPiece,
 					0,
 					MoveFlags::IS_CASTLES
 				));
@@ -790,7 +794,17 @@ namespace NeraChessEngine
 			othogonalSliders &= ~m_PinRays;
 			diagonalSliders &= ~m_PinRays;
 		}
-	
+
+		// moveMask already excludes friendly pieces, so an occupied target square
+		// is necessarily an opponent piece -- no lookup needed for the capture flag.
+		// The moving piece is fixed by which bitboard the loop is walking; only
+		// rook-vs-queen (resp. bishop-vs-queen) needs disambiguating.
+		PieceType friendlyRook = m_WhiteToMove ? PieceType::WHITE_ROOK : PieceType::BLACK_ROOK;
+		PieceType friendlyBishop = m_WhiteToMove ? PieceType::WHITE_BISHOP : PieceType::BLACK_BISHOP;
+		PieceType friendlyQueen = m_WhiteToMove ? PieceType::WHITE_QUEEN : PieceType::BLACK_QUEEN;
+		Bitboard friendlyRooks = m_BoardState.pieceBitboards[friendlyRook];
+		Bitboard friendlyBishops = m_BoardState.pieceBitboards[friendlyBishop];
+
 		// Ortho
 		while (othogonalSliders != 0)
 		{
@@ -802,15 +816,17 @@ namespace NeraChessEngine
 				moveSquares &= s_AlignMask[startSquare][m_FriendlyKingSquare];
 			}
 
+			PieceType movePiece = Square(startSquare).ContainsSquare(friendlyRooks) ? friendlyRook : friendlyQueen;
+
 			while (moveSquares != 0)
 			{
 				int targetSquare = BitUtil::PopLSB(moveSquares);
 				m_LegalMoves.push(Move(
-					startSquare, 
+					startSquare,
 					targetSquare,
-					GetPiece(startSquare),
+					movePiece,
 					0,
-					GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE
+					Square(targetSquare).ContainsSquare(m_OpponentPieces) ? MoveFlags::IS_CAPTURE : 0
 				));
 			}
 		}
@@ -825,15 +841,17 @@ namespace NeraChessEngine
 				moveSquares &= s_AlignMask[startSquare][m_FriendlyKingSquare];
 			}
 
+			PieceType movePiece = Square(startSquare).ContainsSquare(friendlyBishops) ? friendlyBishop : friendlyQueen;
+
 			while (moveSquares != 0)
 			{
 				int targetSquare = BitUtil::PopLSB(moveSquares);
 				m_LegalMoves.push(Move(
 					startSquare,
 					targetSquare,
-					GetPiece(startSquare),
+					movePiece,
 					0,
-					GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE
+					Square(targetSquare).ContainsSquare(m_OpponentPieces) ? MoveFlags::IS_CAPTURE : 0
 				));
 			}
 		}
@@ -844,6 +862,8 @@ namespace NeraChessEngine
 		Bitboard knights = m_FriendlyKnights & m_NotPinRays;
 		Bitboard moveMask = ~m_FriendlyPieces & m_CheckRayBitmask;
 
+		PieceType friendlyKnight = m_WhiteToMove ? PieceType::WHITE_KNIGHT : PieceType::BLACK_KNIGHT;
+
 		while (knights != 0)
 		{
 			int knightSquare = BitUtil::PopLSB(knights);
@@ -853,11 +873,11 @@ namespace NeraChessEngine
 			{
 				int targetSquare = BitUtil::PopLSB(moveSquares);
 				m_LegalMoves.push(Move(
-					knightSquare, 
-					targetSquare, 
-					GetPiece(knightSquare),
+					knightSquare,
+					targetSquare,
+					friendlyKnight,
 					0,
-					GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : (uint8_t)MoveFlags::IS_CAPTURE
+					Square(targetSquare).ContainsSquare(m_OpponentPieces) ? (uint8_t)MoveFlags::IS_CAPTURE : 0
 				));
 			}
 		}
@@ -970,7 +990,9 @@ namespace NeraChessEngine
 			uint8_t startSquare = targetSquare - pushOffset;
 			if (!IsPinned(startSquare))
 			{
-				GeneratePromotions(startSquare, targetSquare);
+				// A push target is always an empty square (singlePush was masked
+				// by ~m_AllPieces), so this can never be a capture.
+				GeneratePromotions(startSquare, targetSquare, false);
 			}
 		}
 
@@ -982,7 +1004,9 @@ namespace NeraChessEngine
 
 			if (!IsPinned(startSquare) || s_AlignMask[startSquare][m_FriendlyKingSquare] == s_AlignMask[targetSquare][m_FriendlyKingSquare])
 			{
-				GeneratePromotions(startSquare, targetSquare);
+				// captureA/B were masked by m_OpponentPieces before the promotion-rank
+				// filter, so this is always a capture.
+				GeneratePromotions(startSquare, targetSquare, true);
 			}
 		}
 
@@ -993,7 +1017,7 @@ namespace NeraChessEngine
 
 			if (!IsPinned(startSquare) || s_AlignMask[startSquare][m_FriendlyKingSquare] == s_AlignMask[targetSquare][m_FriendlyKingSquare])
 			{
-				GeneratePromotions(startSquare, targetSquare);
+				GeneratePromotions(startSquare, targetSquare, true);
 			}
 		}
 
@@ -1032,15 +1056,19 @@ namespace NeraChessEngine
 	
 	}
 
-	void MoveGenerator::GeneratePromotions(Square startSquare, Square targetSquare)
+	void MoveGenerator::GeneratePromotions(Square startSquare, Square targetSquare, bool isCapture)
 	{
+		// The caller already knows whether targetSquare is occupied (it built the
+		// candidate mask from either an empty-square push or an opponent-masked
+		// capture), so isCapture replaces a redundant GetPiece lookup here.
+		const uint8_t flags = MoveFlags::IS_PROMOTION | (isCapture ? MoveFlags::IS_CAPTURE : 0);
 
 		m_LegalMoves.push(Move(
 			startSquare,
 			targetSquare,
 			m_WhiteToMove ? PieceType::WHITE_PAWN : PieceType::BLACK_PAWN,
 			m_WhiteToMove ? PieceType::WHITE_QUEEN : PieceType::BLACK_QUEEN,
-			MoveFlags::IS_PROMOTION | (GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE)
+			flags
 		));
 
 		m_LegalMoves.push(Move(
@@ -1048,15 +1076,15 @@ namespace NeraChessEngine
 			targetSquare,
 			m_WhiteToMove ? PieceType::WHITE_PAWN : PieceType::BLACK_PAWN,
 			m_WhiteToMove ? PieceType::WHITE_ROOK : PieceType::BLACK_ROOK,
-			MoveFlags::IS_PROMOTION | (GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE)
+			flags
 		));
 
 		m_LegalMoves.push(Move(
-			startSquare, 
-			targetSquare, 
+			startSquare,
+			targetSquare,
 			m_WhiteToMove ? PieceType::WHITE_PAWN   : PieceType::BLACK_PAWN ,
 			m_WhiteToMove ? PieceType::WHITE_BISHOP : PieceType::BLACK_BISHOP ,
-			MoveFlags::IS_PROMOTION | (GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE)
+			flags
 		));
 
 		m_LegalMoves.push(Move(
@@ -1064,7 +1092,7 @@ namespace NeraChessEngine
 			targetSquare,
 			m_WhiteToMove ? PieceType::WHITE_PAWN : PieceType::BLACK_PAWN,
 			m_WhiteToMove ? PieceType::WHITE_KNIGHT : PieceType::BLACK_KNIGHT,
-			MoveFlags::IS_PROMOTION | (GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : MoveFlags::IS_CAPTURE)
+			flags
 		));
 
 

--- a/NeraChessEngine/src/MoveGenerator.h
+++ b/NeraChessEngine/src/MoveGenerator.h
@@ -16,7 +16,9 @@ namespace NeraChessEngine
 		MoveGenerator() = default;
 		~MoveGenerator() = default;
 
-		MoveList<218> GenerateMoves(const BoardState& board);
+		const MoveList<218>& GenerateMoves(const BoardState& board);
+
+		const MoveList<218>& GetLegalMoves() const { return m_LegalMoves; }
 
 		bool InCheck() const { return m_InCheck; };
 
@@ -32,7 +34,7 @@ namespace NeraChessEngine
 		void CalculateKnightMoves();
 		void CalculatePawnMoves();
 
-		void GeneratePromotions(Square startSquare, Square targetSquare);
+		void GeneratePromotions(Square startSquare, Square targetSquare, bool isCapture);
 
 		static Bitboard GetSlidingAttacks(Square square, Bitboard blockers, bool orthogonal);
 


### PR DESCRIPTION
## Summary

Implements parts (b) and (c) of #35 -- the tree-identical, no-strength-test-needed subset of that issue. Part (a) (a captures-only quiescence generator mode, which changes tree shape in rare horizon-stalemate cases and needs either a stalemate-trap suite or a strength test) is left out of scope for this PR.

- **(b)** `MoveGenerator`'s emit loops (`CalculateKingMoves`, `CalculateSlidingMoves`, `CalculateKnightMoves`, `GeneratePromotions`) stop calling `GetPiece(Square)` -- a 12-bitboard linear scan -- once per emitted move.
- **(c)** `MoveGenerator::GenerateMoves` now returns `const MoveList<218>&` instead of `MoveList<218>` by value, and `ChessBoard` reads through that reference instead of keeping its own copy.

## Problem

Issue #35 profiled move generation at 13.4% of search instructions and identified three separable causes. This PR addresses two of them:

- `GetPiece` is called once per emitted move to answer "is the target occupied?" and again for the moving piece, even though both answers are already implied by state the generator computed while building the move mask: the move masks used by the king/sliding/knight loops already exclude friendly-occupied squares, so any occupied target is necessarily an opponent's, and the moving piece is fixed by which bitboard the loop is walking (a rook-vs-queen or bishop-vs-queen bit test is the only real disambiguation needed for sliders). `GeneratePromotions` re-derived the capture flag via `GetPiece` even though its caller already knew the answer from how it built the candidate mask (an empty-square push vs. an opponent-masked capture).
- `GenerateMoves` returned `MoveList<218>` (an ~880-byte array) by value out of a member (no NRVO possible), and `ChessBoard::GetLegalMovesRef()` copy-assigned that into a second member -- two ~880-byte copies per generation for a list every caller reads through a reference or copies once more anyway.

## Implementation

- `CalculateKingMoves`/`CalculateSlidingMoves`/`CalculateKnightMoves` replace `GetPiece(targetSquare) == PieceType::NO_PIECE ? 0 : IS_CAPTURE` with `Square(targetSquare).ContainsSquare(m_OpponentPieces) ? IS_CAPTURE : 0`, and replace `GetPiece(startSquare)`/`GetPiece(knightSquare)` with a piece type computed once per loop (a constant for king/knight; one `ContainsSquare` test against the rook/bishop bitboard, falling back to queen, for sliders).
- `GeneratePromotions` gained an `isCapture` parameter; its two call sites already know statically whether the target is a push (never a capture) or a capture-promotion (always a capture), so this removes four `GetPiece` calls per promoted pawn with no per-call lookup at all.
- The pin/check-ray scan in `CalculateAttackMaps` (the one place `GetPiece` is genuinely needed, since it must classify an arbitrary piece on the ray) is left untouched, per the issue's own guidance that it's rare enough not to matter.
- `MoveGenerator::GenerateMoves` returns `const MoveList<218>&`, with a new `GetLegalMoves()` accessor. `ChessBoard` drops its own `m_LegalMoves` member entirely; `GetLegalMovesRef()`, `GetGameOver()`, and `IsInCheckByMoveGeneration()` all read through `m_MoveGenerator.GetLegalMoves()` instead.

## Why this approach

Both changes rely on invariants that already held in the existing code (the move masks already excluded friendly pieces; the copied values were never mutated independently) rather than changing any decision the generator makes, so they need no strength test -- the issue's own validation bar for this class of change is node-count identity, which is what's demonstrated below.

## Validation

```
Release build (Engine/NNUE/Search/UCI/Tests): PASS, warnings-as-errors clean
Debug build (asserts, incl. accumulator full-refresh verification): PASS
NeraChessTests, Release + Debug, with the shipped network (nera.nnue): PASS
  (perft, make/undo, TranspositionTable, NNUE format/accumulator invariants,
   tactical/strategic search choices, opening-book index)
UCI pondering regression (scripts/Test-UciPonder.py): PASS
```

**Tree identity** (the acceptance gate for this class of change) -- fixed-depth UCI search (`go depth 12` and `go depth 13`, single thread, 16 MiB hash, book off) against `origin/main` (`901cd40`) on five probe positions (startpos, kiwipete, a closed Italian, the Lasker KQ vs. KR endgame `8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8`, and a Ruy Lopez middlegame): **node counts, scores, and best moves bit-identical** on every position at both depths. `--search-bench` (fixed depth 6, three positions) is also node-for-node identical against baseline.

**Instruction count** (callgrind `Ir`, single-threaded UCI binary, fixed depth 9, same five positions). The one-time cost of network loading and opening-book indexing (which runs even with `OwnBook=false`) dominates the raw total, so it's isolated with a `go depth 1` measurement per build and subtracted out, matching #35's own "search-only denominator" methodology:

| Position | Baseline search-only Ir | Candidate search-only Ir | Δ |
| --- | ---: | ---: | ---: |
| startpos | 200,148,812 | 190,694,971 | -4.72% |
| kiwipete | 532,718,860 | 510,459,533 | -4.18% |
| closed | 177,062,656 | 168,123,306 | -5.05% |
| endgame | 32,845,643 | 31,303,436 | -4.70% |
| ruylopez | 117,214,105 | 111,278,126 | -5.06% |
| **aggregate** | **1,059,990,076** | **1,011,859,372** | **-4.54%** |

(Callgrind `Ir` counts are exactly reproducible for a given binary -- verified by repeating the same measurement three times and getting identical counts -- so these deltas reflect the code change, not run-to-run noise.)

**Wall clock** -- same five positions, `go depth 13`, three interleaved repeats of baseline vs. candidate (node counts identical on every repeat, 2,907,347 total nodes): +5.6%, +5.9%, and -0.0% (noise) nps improvement, consistent with the smaller instruction count.

## Strength test

Not run. Per #35's own validation section, parts (b) and (c) need no strength test if the trees are provably identical -- that's exactly what's demonstrated above (bit-identical node counts, scores, and best moves at two fixed depths across five positions). There is no move-selection behavior for a 1,000-game screening match to measure.

## Risks

- (b) rests on the invariant that the emit masks used by `CalculateKingMoves`/`CalculateSlidingMoves`/`CalculateKnightMoves` never include friendly-occupied squares. That invariant already existed in the code (`~m_FriendlyPieces & ...` is how each of those masks is built); this PR adds a comment at each capture-flag site noting it, but doesn't change the mask construction itself.
- Part (a) of #35 (the captures-only quiescence generator, which changes tree shape via the stalemate-at-horizon edge case) is intentionally out of scope here -- it needs its own validation (a stalemate-trap suite or a strength test) and is left for a follow-up.

Closes nothing on its own since it only implements part of #35; the issue stays open for part (a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpUJ7enz6HGHeBjhuLFomQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpUJ7enz6HGHeBjhuLFomQ)_