### PR TITLE
Scale iterative-deepening soft time by root-move stability

### DIFF
--- a/NeraChessSearch/src/SearchEngine.cpp
+++ b/NeraChessSearch/src/SearchEngine.cpp
@@ -270,6 +270,13 @@ namespace NeraChessSearch
             return result;
         }
         Score previousScore = SCORE_DRAW;
+        // Number of consecutive completed iterations, ending at the previous
+        // depth, whose root move equalled the one just confirmed. Local to this
+        // call so each helper thread tracks its own root order independently;
+        // harmless, since only the main worker's iterationCallback/stop timing
+        // is observed by Search().
+        Move previousIterationMove = 0;
+        int stableIterations = 0;
 
         for (int depth = 1; depth <= m_Limits.maxDepth; ++depth)
         {
@@ -350,11 +357,27 @@ namespace NeraChessSearch
             if (m_Limits.iterationCallback)
                 m_Limits.iterationCallback(result);
 
+            if (depth > 1 && iteration.move == previousIterationMove)
+                ++stableIterations;
+            else
+                stableIterations = 0;
+            previousIterationMove = iteration.move;
+
             if (std::abs(result.score) >= SCORE_MATE - MAX_PLY)
                 break;
-            if (m_Limits.softTime.count() > 0 &&
-                TimeControlElapsed() >= m_Limits.softTime)
-                break;
+            if (m_Limits.softTime.count() > 0)
+            {
+                // Below this depth there have been too few iterations for
+                // stability to mean anything; use the plain soft limit.
+                constexpr int kStabilityScalingMinDepth = 6;
+                const std::chrono::milliseconds effectiveSoftTime =
+                    depth >= kStabilityScalingMinDepth
+                        ? ScaleSoftTimeForStability(m_Limits.softTime, m_Limits.hardTime,
+                            stableIterations)
+                        : m_Limits.softTime;
+                if (TimeControlElapsed() >= effectiveSoftTime)
+                    break;
+            }
         }
 
         // Every MakeMove in the search must be matched by an accumulator push
@@ -1005,6 +1028,43 @@ namespace NeraChessSearch
     {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
+    }
+
+    std::chrono::milliseconds SearchEngine::ScaleSoftTimeForStability(
+        std::chrono::milliseconds softTime, std::chrono::milliseconds hardTime,
+        int stableIterations)
+    {
+        // Iterative deepening's marginal value is not constant: an iteration that
+        // repeats a root move settled several plies ago tells the search almost
+        // nothing new, while one that just changed the root move is exactly the
+        // case a bigger budget is for. stableIterations is how many consecutive
+        // completed iterations agreed on the current root move; more of it means
+        // less reason to keep searching this move right now.
+        //
+        // Percent of the plain soft limit to spend, indexed by
+        // min(stableIterations, kMaxTrackedStability). Centred at index 2 (three
+        // iterations in a row on the same move counts as an unremarkable case,
+        // not evidence to cut) rather than at index 0, so a search that has only
+        // just settled still gets a real boost instead of merely losing less than
+        // a long-settled one -- a curve that only ever scales down is a time cut
+        // wearing a stability costume. The downward side is steeper and reaches
+        // further than the upward side: scaling down redistributes time for free
+        // through TimeManagement::CalculateLimits' remaining/estimatedMovesLeft
+        // term on the next move, while scaling up needs the explicit hardTime
+        // clamp below to stay safe.
+        constexpr int kMaxTrackedStability = 6;
+        constexpr std::array<int, kMaxTrackedStability + 1> kPercentByStability{
+            130, 115, 100, 85, 72, 62, 55
+        };
+
+        const int index = std::clamp(stableIterations, 0, kMaxTrackedStability);
+        const int64_t scaledMilliseconds = softTime.count() * kPercentByStability[index] / 100;
+
+        // hardTime is left untouched as the absolute ceiling (the clock-safety
+        // margin in CalculateLimits is sized against it, not against this
+        // scaling), so the amplified end of the curve is clamped to it explicitly
+        // rather than relying on the separate hard-limit check to catch it.
+        return std::min(std::chrono::milliseconds{ scaledMilliseconds }, hardTime);
     }
 
     bool SearchEngine::IsDrawOrTerminal(const ChessBoard& board,

--- a/NeraChessSearch/src/SearchEngine.h
+++ b/NeraChessSearch/src/SearchEngine.h
@@ -69,6 +69,17 @@ namespace NeraChessSearch
         // accumulator rather than using the search's stack.
         static Score Evaluate(const NeraChessEngine::ChessBoard& board);
 
+        // Scales softTime by how many consecutive completed iterations have
+        // agreed on the current root move, clamped to hardTime. Pure function of
+        // its arguments (no search state), kept out of TimeManagement so
+        // CalculateLimits' own pinned test coverage and its "no view of the
+        // search" contract stay untouched. Public for direct unit testing of the
+        // curve; see the definition for its shape and why it is centred rather
+        // than a pure cut.
+        static std::chrono::milliseconds ScaleSoftTimeForStability(
+            std::chrono::milliseconds softTime, std::chrono::milliseconds hardTime,
+            int stableIterations);
+
     private:
         struct SharedSearchState
         {

--- a/NeraChessTests/src/main.cpp
+++ b/NeraChessTests/src/main.cpp
@@ -2370,6 +2370,44 @@ namespace
         blackToMove.Stop();
     }
 
+    void TestSoftTimeStabilityScaling()
+    {
+        using namespace std::chrono;
+        using NeraChessSearch::SearchEngine;
+
+        const milliseconds soft{ 1000 };
+        const milliseconds hard{ 1500 };
+
+        // A move that just changed (stableIterations == 0) gets amplified, not cut.
+        Require(SearchEngine::ScaleSoftTimeForStability(soft, hard, 0) > soft,
+            "an unstable root move did not get more time than the plain soft limit");
+        // A handful of iterations in a row on the same move is treated as
+        // unremarkable, not as grounds to cut the budget yet.
+        Require(SearchEngine::ScaleSoftTimeForStability(soft, hard, 2) == soft,
+            "the curve is not centred at a small stability count");
+        // A long-settled move gets a shorter budget than the plain soft limit,
+        // and the curve is monotonically non-increasing in stability.
+        milliseconds previous = SearchEngine::ScaleSoftTimeForStability(soft, hard, 0);
+        for (int stable = 1; stable <= 10; ++stable)
+        {
+            const milliseconds scaled = SearchEngine::ScaleSoftTimeForStability(soft, hard, stable);
+            Require(scaled <= previous,
+                "soft-time scaling is not monotonically non-increasing in stability");
+            previous = scaled;
+        }
+        Require(SearchEngine::ScaleSoftTimeForStability(soft, hard, 6) < soft,
+            "a long-settled root move was not given a shorter budget");
+        // Stability beyond the tracked cap must not keep shrinking the budget.
+        Require(SearchEngine::ScaleSoftTimeForStability(soft, hard, 6) ==
+            SearchEngine::ScaleSoftTimeForStability(soft, hard, 50),
+            "stability scaling did not saturate at its tracked cap");
+
+        // hardTime is an absolute ceiling: amplifying an already-large soft
+        // limit must never be allowed to exceed it.
+        Require(SearchEngine::ScaleSoftTimeForStability(milliseconds{ 1400 }, hard, 0) == hard,
+            "amplified soft time was not clamped to hardTime");
+    }
+
     void TestOpeningBook()
     {
         NeraChessSearch::OpeningBook book(
@@ -2545,6 +2583,7 @@ int main(int argc, char** argv)
         TestSliderAttackLookups();
         TestStaticExchangeEvaluation();
         TestClockAndTimeManagement();
+        TestSoftTimeStabilityScaling();
         TestOpeningBook();
         std::cout << "All NeraChess engine tests passed.\n";
         return 0;


### PR DESCRIPTION
## Summary

`SearchWorker`'s between-iteration stopping check now scales the soft-time budget by how many consecutive completed iterations have agreed on the root move, instead of comparing elapsed time against a fixed limit regardless of how settled the search is.

Closes #38.

## Problem

Issue #38 measured NeraChess's time management at `10+0.1` self-play and found that the soft-time check (`SearchEngine.cpp:355-357` before this change) treats every search identically: a root move that has been unchanged for six-plus iterations gets the same budget as one that just flipped on the last completed iteration. 76-79% of searches spend their whole soft-time budget re-confirming a move that stopped moving four-plus iterations earlier, while the ~10% of searches that stop with the root move still in flux get no extra time for it. Because `softTime = remaining / estimatedMovesLeft + increment * 3/4`, time saved on settled moves is not lost — it enlarges the budget of every later move in the game, including sharp ones.

## Implementation

- `SearchWorker` tracks `stableIterations`, the number of consecutive completed iterations whose root move matched the previous one, reset whenever the move changes.
- From depth 6 onward, the soft-time comparison uses a new `SearchEngine::ScaleSoftTimeForStability(softTime, hardTime, stableIterations)` helper instead of the raw `softTime`. Below depth 6 (too few iterations for stability to mean anything) and whenever `softTime` is unset (fixed-depth/fixed-node search), behavior is unchanged.
- The curve is a percent-of-`softTime` table indexed by `min(stableIterations, 6)`: `{130, 115, 100, 85, 72, 62, 55}`. It is centred at index 2 (three iterations in a row on the same move is unremarkable, not grounds to cut) rather than at index 0, and amplifies up to 1.3x when the move just changed rather than only ever cutting — a curve that only shrinks the budget is a time cut wearing a stability costume, per the issue's own design constraint. The downward side is steeper (to 0.55x) than the upward side, per the issue's preference for scaling down on stability over scaling up on instability, since scaling down redistributes for free through `CalculateLimits`' `remaining / estimatedMovesLeft` term on the next move.
- The amplified end of the curve is explicitly clamped to `hardTime`, which is left completely untouched as the absolute ceiling — the existing mid-search `ShouldStop()` hard-time check (unmodified) is what actually enforces it.
- The change stays entirely inside `SearchWorker`'s loop and out of `TimeManagement::CalculateLimits`, per the issue's explicit design constraint: that function has no view of the search, and `NeraChessTests`' `TestClockAndTimeManagement` pins its output and is left unmodified.

## Why this approach

A pure "only ever scale down" curve (the issue's own prototype) redistributes time but isn't obviously an improvement in itself — it just changes when the engine stops, without guidance on whether stopping earlier on stable searches is worth more than the lost depth. Centring the curve and amplifying the unstable case directly targets the mechanism the issue identifies as valuable (redistribution toward searches that are still learning something) while keeping total time spent roughly flat rather than turning into a disguised time cut. Keeping `hardTime` untouched and clamping the amplified case to it means no code path introduced by this change can produce a time loss that the pre-existing hard-time check wouldn't already catch.

## Validation

```
Release build (Engine/NNUE/Search/UCI/Tests): PASS, warnings-as-errors clean
Debug build (asserts, incl. accumulator full-refresh verification): PASS
NeraChessTests, Release + Debug, with the shipped network (nera.nnue): PASS
  (perft, make/undo, TranspositionTable, NNUE, tactical/strategic search
   choices, opening-book index, TestClockAndTimeManagement unmodified,
   plus a new TestSoftTimeStabilityScaling covering the curve's centering,
   monotonicity, saturation at the tracked cap, and the hardTime clamp)
UCI pondering regression (scripts/Test-UciPonder.py): PASS
```

**Tree identity for fixed-depth/fixed-node search.** `go depth`/`go nodes` never set `softTime` (`UciSession.cpp`), so `ScaleSoftTimeForStability` is provably unreachable on that path — perft and any node-count-based test are unaffected by construction, not just by observation.

**Clock safety.** Self-play at `10+0.1` (128 MiB hash, 1 thread, book off, `nera.nnue`) via a UCI driver reproducing real wtime/btime/increment bookkeeping: multiple runs of 6-24 plies with full per-search timing instrumentation showed every search finishing within its `hardTime` budget, and a 16-ply run of the actual candidate binary showed move times consistently in the expected 220-660ms range with no overruns. (An earlier apparent 20-30s overrun during investigation turned out to be a side effect of running a heavy parallel `make -j4` build concurrently with the timing-sensitive test in the same 4-CPU sandbox, not an engine defect — it did not reproduce under isolated conditions on either the candidate or baseline binary.)

## Strength test

Sequential SPRT test via `.github/workflows/strength-test.yml`, default configuration (`10+0.1`, `elo1=5`, single thread, 128 MiB hash, NeraChess book off, `UHO_4060_v4.epd` openings, paired/reversed-colour games).

```
Candidate: dbd8f9a73a6102d0836a81421679450b5ec8ea75
Baseline:  44e240915be536596f520e8868602dc9acac04d3 (main)
Verdict:   Accepted: improvement (H1 accepted)
Games:     2000 (stages 1+2; stopped after stage 2, stages 3-7 skipped)
W/D/L:     592 / 933 / 475
Score:     52.92%
Estimated Elo: +20.3
Approximate paired 95% interval: [+10.8, +30.0]
Pentanomial: [35, 187, 454, 274, 50]
Log likelihood ratio: +3.75 (crossed the +2.94 accept boundary for H1: Elo >= 5)
Workflow run: https://github.com/raphaelhounsiagaman/NeraChess/actions/runs/34025750119
```

This is a screening-test result from a sequential test, not proof of the exact Elo figure — the reported interval is a descriptive summary of the games played rather than an independently-valid confidence interval, since a sequential test consults it repeatedly. What the SPRT verdict itself does certify, at the stated 5% error rate, is that the true effect clears the `elo1 = 5` threshold; +20.3 is the point estimate, not a guaranteed figure.

## Risks

- **Stability is not proof.** A move can hold for six iterations and be refuted at the seventh; the earlier stop this change causes in that case is exactly how it would lose Elo if it did. The depth-6 gate and the floor on the scaling factor (0.55x, never zero) bound this, and the strength test result suggests it isn't happening often enough to matter at `10+0.1`, but it isn't something a benchmark can rule out in general — only games can, which is why this went through the full strength test rather than being accepted on tree-identity grounds alone.
- **Helper threads** (when `Threads > 1`) each compute their own `stableIterations` from their own rotated root move order, independently of the main worker. This is harmless — `Search()`'s stopping decision is driven by the main worker regardless — but is a deliberate consequence of keeping the state local to `SearchWorker`, not a shared/synchronized signal. The strength test ran at the default `Threads=1`, matching `docs/Strength-Testing.md`.
- **The curve's exact shape (percentages, depth-6 gate, cap of 6) is a reasoned choice**, not a re-derivation of the issue's own prototype numbers (which used a pure scale-down curve). A different curve might perform better or worse; this PR's evidence is that this specific curve measured an improvement, not that it is optimal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1eazuFcbE6oLhMV85Fico

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1eazuFcbE6oLhMV85Fico)_